### PR TITLE
Initial implementation: Atomic/Log/Manifest/Lock/Run runtime

### DIFF
--- a/.github/scripts/setup_project.jl
+++ b/.github/scripts/setup_project.jl
@@ -22,8 +22,12 @@ for file in files_to_fix
             content = replace(content, r"^name = \".*\""m => "name = \"$new_name\"")
             content = replace(content, r"^uuid = \".*\""m => "uuid = \"$new_uuid\"")
         elseif file == "docs/Project.toml"
-            content = replace(content, Regex("$(new_name) = \".*\"") => "$(new_name) = \"$new_uuid\"")
-            content = replace(content, r"^uuid = \".*\""m => "uuid = \"$(string(uuid4()))\"")
+            content = replace(
+                content, Regex("$(new_name) = \".*\"") => "$(new_name) = \"$new_uuid\""
+            )
+            content = replace(
+                content, r"^uuid = \".*\""m => "uuid = \"$(string(uuid4()))\""
+            )
         end
         write(file, content)
     end

--- a/Project.toml
+++ b/Project.toml
@@ -18,18 +18,16 @@ SlurmClusterManager = "c82cd089-7bf7-41d7-976b-6b5d413cbe0a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
-# ParamIO is pinned to the `feat/canonical` branch until that PR merges.
-# After merge, remove `rev` so main is used.
-ParamIO   = {url = "git@github.com:sotashimozono/ParamIO.jl.git", rev = "feat/canonical"}
-DataVault = {url = "git@github.com:sotashimozono/DataVault.jl.git"}
+DataVault = {rev = "main", url = "git@github.com:sotashimozono/DataVault.jl.git"}
+ParamIO = {rev = "feat/canonical", url = "git@github.com:sotashimozono/ParamIO.jl.git"}
 
 [compat]
+DataVault = "0.4"
 Dates = "1.11"
 Distributed = "1.11"
 JLD2 = "0.6"
 JSON3 = "1"
 LinearAlgebra = "1.11"
-DataVault = "0.4"
 Logging = "1.11"
 ParamIO = "0.3"
 Printf = "1.11"

--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,8 @@ SlurmClusterManager = "c82cd089-7bf7-41d7-976b-6b5d413cbe0a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
-DataVault = {rev = "main", url = "git@github.com:sotashimozono/DataVault.jl.git"}
-ParamIO = {rev = "feat/canonical", url = "git@github.com:sotashimozono/ParamIO.jl.git"}
+DataVault = {rev = "main", url = "https://github.com/sotashimozono/DataVault.jl.git"}
+ParamIO = {rev = "feat/canonical", url = "https://github.com/sotashimozono/ParamIO.jl.git"}
 
 [compat]
 DataVault = "0.4"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,41 @@ uuid = "be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"
 version = "0.1.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
+[deps]
+DataVault = "23f5f8f6-b4da-40ee-8c72-c53b6c5de94f"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+ParamIO = "938a3ac2-d340-473c-bcf1-88af577e4ccf"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+SlurmClusterManager = "c82cd089-7bf7-41d7-976b-6b5d413cbe0a"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[sources]
+# ParamIO is pinned to the `feat/canonical` branch until that PR merges.
+# After merge, remove `rev` so main is used.
+ParamIO   = {url = "git@github.com:sotashimozono/ParamIO.jl.git", rev = "feat/canonical"}
+DataVault = {url = "git@github.com:sotashimozono/DataVault.jl.git"}
+
+[compat]
+Dates = "1.11"
+Distributed = "1.11"
+JLD2 = "0.6"
+JSON3 = "1"
+LinearAlgebra = "1.11"
+DataVault = "0.4"
+Logging = "1.11"
+ParamIO = "0.3"
+Printf = "1.11"
+SHA = "0.7"
+SlurmClusterManager = "0.1, 1"
+TOML = "1"
+julia = "1.11"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/AtomicIO.jl
+++ b/src/AtomicIO.jl
@@ -1,0 +1,51 @@
+# AtomicIO — NFS-safe atomic write helpers (痛点 #8)
+
+"""
+    atomic_write(write_fn, path)
+
+Write `path` atomically: the target either doesn't exist or contains the
+complete output. Achieved by `tmp` file + fsync + POSIX rename.
+
+- Parent directory is created if missing.
+- If `write_fn` throws, the tmp file is cleaned up and `path` is untouched.
+- Safe under NFS (uses `rename`, which is atomic there).
+
+```julia
+atomic_write("out/data.jld2") do io
+    write(io, payload)
+end
+```
+"""
+function atomic_write(write_fn::Function, path::AbstractString)
+    mkpath(dirname(path))
+    tmp = string(path, ".tmp.", getpid(), ".", rand(UInt32))
+    try
+        open(tmp, "w") do io
+            write_fn(io)
+            flush(io)
+            try
+                ccall(:fsync, Cint, (Cint,), fd(io))
+            catch
+                # fsync not available on this FS; rename is still atomic
+            end
+        end
+        mv(tmp, path; force=true)
+    catch
+        # Clean up tmp on failure; do NOT touch target path
+        isfile(tmp) && try
+            rm(tmp; force=true)
+        catch
+        end
+        rethrow()
+    end
+    return path
+end
+
+"""
+    atomic_touch(path)
+
+Create an empty file at `path` atomically (for `.done` markers).
+"""
+atomic_touch(path::AbstractString) = atomic_write(_ -> nothing, path)
+
+export atomic_write, atomic_touch

--- a/src/EventLog.jl
+++ b/src/EventLog.jl
@@ -1,0 +1,53 @@
+# EventLog — structured JSONL event logging (痛点 #7)
+#
+# Do NOT add a per-item `println` API here. Structured events only.
+# The 300MB println logs in FiniteTemperature.jl came from per-item prints;
+# this module exists to make that impossible by design.
+
+using Dates
+using JSON3
+
+"""
+    EventLog(path)
+
+Append-only JSONL event log with thread-safe writes.
+
+Standard event kinds:
+  :stage_start, :stage_done
+  :key_start, :key_done
+  :lock_busy, :lock_reclaimed
+  :error, :gave_up, :retry
+  :skip_complete
+
+Downstream code should use `log_event` and never `println` directly.
+"""
+struct EventLog
+    path::String
+    lock::ReentrantLock
+end
+
+EventLog(path::AbstractString) = EventLog(String(path), ReentrantLock())
+
+"""
+    log_event(log, kind; kwargs...)
+
+Append one JSON object as a line to `log.path`. Always includes `ts` (ISO-8601)
+and `kind` (Symbol). Extra fields come from `kwargs`.
+"""
+function log_event(log::EventLog, kind::Symbol; kwargs...)
+    rec = (; ts=string(now()), kind=String(kind), kwargs...)
+    # Build full line with newline and write in a single syscall so O_APPEND
+    # preserves line atomicity across processes (multi-master contention).
+    line = string(JSON3.write(rec), '\n')
+    lock(log.lock) do
+        mkpath(dirname(log.path))
+        # Open append mode, do one write, close. On POSIX, writes < PIPE_BUF
+        # (4096 bytes) with O_APPEND are atomic even across processes.
+        open(log.path, "a") do io
+            write(io, line)
+        end
+    end
+    return nothing
+end
+
+export EventLog, log_event

--- a/src/InitWorkers.jl
+++ b/src/InitWorkers.jl
@@ -35,15 +35,16 @@ function init_workers!(; mode::Symbol=:auto, master_blas::Int=1, verbose::Bool=t
 
     elseif actual == :threads
         BLAS.set_num_threads(master_blas)
-        verbose && _log_init("threads", Threads.nthreads() - 1,
-                             master_blas, master_blas)
+        verbose && _log_init("threads", Threads.nthreads() - 1, master_blas, master_blas)
         return :threads
 
     elseif actual == :distributed
-        n_workers = parse(Int, get(ENV, "JULIA_SLURM_N_WORKERS",
-                                    get(ENV, "SLURM_NTASKS", "1")))
-        worker_blas = parse(Int, get(ENV, "JULIA_WORKER_CPUS",
-                                      get(ENV, "SLURM_CPUS_PER_TASK", "1")))
+        n_workers = parse(
+            Int, get(ENV, "JULIA_SLURM_N_WORKERS", get(ENV, "SLURM_NTASKS", "1"))
+        )
+        worker_blas = parse(
+            Int, get(ENV, "JULIA_WORKER_CPUS", get(ENV, "SLURM_CPUS_PER_TASK", "1"))
+        )
         if n_workers > 0 && nprocs() == 1
             project = dirname(Base.active_project())
             addprocs(n_workers; exeflags="--project=$project")
@@ -53,10 +54,12 @@ function init_workers!(; mode::Symbol=:auto, master_blas::Int=1, verbose::Bool=t
         return :distributed
 
     elseif actual == :slurm
-        n_workers = parse(Int, get(ENV, "JULIA_SLURM_N_WORKERS",
-                                    get(ENV, "SLURM_NTASKS", "0")))
-        worker_blas = parse(Int, get(ENV, "JULIA_WORKER_CPUS",
-                                      get(ENV, "SLURM_CPUS_PER_TASK", "1")))
+        n_workers = parse(
+            Int, get(ENV, "JULIA_SLURM_N_WORKERS", get(ENV, "SLURM_NTASKS", "0"))
+        )
+        worker_blas = parse(
+            Int, get(ENV, "JULIA_WORKER_CPUS", get(ENV, "SLURM_CPUS_PER_TASK", "1"))
+        )
         if n_workers > 0 && nprocs() == 1
             project = dirname(Base.active_project())
             mgr = withenv("SLURM_NTASKS" => string(n_workers)) do

--- a/src/InitWorkers.jl
+++ b/src/InitWorkers.jl
@@ -1,0 +1,111 @@
+# InitWorkers — unified worker bootstrap for Threads / Distributed / SLURM
+#
+# Absorbs the existing `HybridInit.init_hybrid_scm!` from
+# `Vault/.vault/templates/templateHPC.jl/src/parallel/init.jl` so that
+# templateHPC can be reduced to a thin wrapper.
+
+using Distributed
+using LinearAlgebra
+using SlurmClusterManager
+
+"""
+    init_workers!(; mode=:auto, master_blas=1, verbose=true) -> Symbol
+
+Bootstrap worker processes / threads according to `mode`. Returns the mode
+that was actually used.
+
+- `:auto`       — pick `:slurm` if `SLURM_JOB_ID` is set, else `:threads` if
+                  `Threads.nthreads() > 1`, else `:sequential`
+- `:slurm`      — `addprocs(SlurmClusterManager.SlurmManager())` with BLAS
+                  tuning. Absorbs the existing `init_hybrid_scm!` pattern.
+- `:distributed`— `addprocs(JULIA_SLURM_N_WORKERS or 1)` single-node
+- `:threads`    — no-op; caller uses `Threads.@threads`
+- `:sequential` — no-op; caller iterates serially (debug / tests)
+
+Idempotent: calling multiple times with worker processes already present
+does not double-add. BLAS thread settings are always (re)applied.
+"""
+function init_workers!(; mode::Symbol=:auto, master_blas::Int=1, verbose::Bool=true)
+    actual = mode == :auto ? detect_mode() : mode
+
+    if actual == :sequential
+        BLAS.set_num_threads(master_blas)
+        verbose && _log_init("sequential", 0, master_blas, master_blas)
+        return :sequential
+
+    elseif actual == :threads
+        BLAS.set_num_threads(master_blas)
+        verbose && _log_init("threads", Threads.nthreads() - 1,
+                             master_blas, master_blas)
+        return :threads
+
+    elseif actual == :distributed
+        n_workers = parse(Int, get(ENV, "JULIA_SLURM_N_WORKERS",
+                                    get(ENV, "SLURM_NTASKS", "1")))
+        worker_blas = parse(Int, get(ENV, "JULIA_WORKER_CPUS",
+                                      get(ENV, "SLURM_CPUS_PER_TASK", "1")))
+        if n_workers > 0 && nprocs() == 1
+            project = dirname(Base.active_project())
+            addprocs(n_workers; exeflags="--project=$project")
+        end
+        _apply_blas(master_blas, worker_blas)
+        verbose && _log_init("distributed", n_workers, master_blas, worker_blas)
+        return :distributed
+
+    elseif actual == :slurm
+        n_workers = parse(Int, get(ENV, "JULIA_SLURM_N_WORKERS",
+                                    get(ENV, "SLURM_NTASKS", "0")))
+        worker_blas = parse(Int, get(ENV, "JULIA_WORKER_CPUS",
+                                      get(ENV, "SLURM_CPUS_PER_TASK", "1")))
+        if n_workers > 0 && nprocs() == 1
+            project = dirname(Base.active_project())
+            mgr = withenv("SLURM_NTASKS" => string(n_workers)) do
+                SlurmClusterManager.SlurmManager()
+            end
+            addprocs(mgr; exeflags="--project=$project")
+        end
+        _apply_blas(master_blas, worker_blas)
+        verbose && _log_init("slurm", n_workers, master_blas, worker_blas)
+        return :slurm
+
+    else
+        error("init_workers!: unknown mode $(actual)")
+    end
+end
+
+"""
+    detect_mode() -> Symbol
+
+Inspect the environment to choose a default mode.
+"""
+function detect_mode()::Symbol
+    haskey(ENV, "SLURM_JOB_ID") && return :slurm
+    Threads.nthreads() > 1 && return :threads
+    return :sequential
+end
+
+function _apply_blas(master_blas::Int, worker_blas::Int)
+    if nprocs() > 1
+        _w = worker_blas
+        @everywhere workers() begin
+            Core.eval(Main, :(using LinearAlgebra))
+        end
+        @everywhere workers() BLAS.set_num_threads($_w)
+    end
+    BLAS.set_num_threads(master_blas)
+    return nothing
+end
+
+function _log_init(mode::String, n_workers::Int, master_blas::Int, worker_blas::Int)
+    # Note: this is init-time informational output, not per-item. OK to use
+    # println here (single line, once per run).
+    println("=== ParallelManager.init_workers! ($mode) ===")
+    println("  workers     : $n_workers")
+    println("  master BLAS : $master_blas")
+    println("  worker BLAS : $worker_blas")
+    println("  total procs : $(nprocs())")
+    println("=============================================")
+    return nothing
+end
+
+export init_workers!, detect_mode

--- a/src/KeyLock.jl
+++ b/src/KeyLock.jl
@@ -1,0 +1,188 @@
+# KeyLock — per-(stage, key) advisory lock via mkdir (痛点 #9, #8)
+#
+# mkdir is atomic on POSIX filesystems including NFS, so this is the safest
+# primitive for multi-master coordination without a central service.
+#
+# Heartbeat + stale reclaim: a background task touches `heartbeat` while the
+# critical section is running. If a master dies, its heartbeat mtime stops
+# updating and another master can reclaim the lock after `stale_after` seconds.
+
+"""
+    KeyLock(dir; stale_after=600.0, heartbeat_interval=60.0)
+
+Advisory lock rooted at `dir`. `try_acquire` succeeds iff `mkdir(dir)` succeeds
+(atomic on POSIX, including NFS).
+
+- `holder` file records `"<hostname>:<pid>"`
+- `heartbeat` file mtime is refreshed every `heartbeat_interval` seconds
+- a lock is **stale** if `time() - mtime(heartbeat) > stale_after`
+- stale locks are automatically reclaimed on contention
+"""
+struct KeyLock
+    dir::String
+    holder::String
+    stale_after::Float64
+    heartbeat_interval::Float64
+end
+
+function KeyLock(dir::AbstractString; stale_after::Real=600.0,
+                 heartbeat_interval::Real=60.0)
+    KeyLock(String(dir),
+            string(gethostname(), ":", getpid()),
+            Float64(stale_after),
+            Float64(heartbeat_interval))
+end
+
+holder_path(l::KeyLock)    = joinpath(l.dir, "holder")
+heartbeat_path(l::KeyLock) = joinpath(l.dir, "heartbeat")
+
+"""
+    touch_heartbeat(l)
+
+Update heartbeat mtime. Safe to call while the lock is held.
+"""
+function touch_heartbeat(l::KeyLock)
+    p = heartbeat_path(l)
+    try
+        touch(p)
+    catch
+        # lock dir might have been reclaimed underneath us
+    end
+    return nothing
+end
+
+"""
+    is_stale(l) -> Bool
+
+True iff the lock clearly belongs to a dead holder:
+- heartbeat exists and is older than `stale_after`, OR
+- heartbeat is missing AND the lock directory itself is older than `stale_after`
+  (covers the edge case where the holder died between `mkdir` and first `touch`).
+
+Returns false during the brief window between `mkdir` and the first
+`touch(heartbeat)` of a live acquirer — otherwise a concurrent contender
+would reclaim a perfectly healthy lock. This is the race that bit the
+heartbeat test in todo 06.
+"""
+function is_stale(l::KeyLock)::Bool
+    isdir(l.dir) || return true  # nothing there → stale (or never held)
+    hb = heartbeat_path(l)
+    if isfile(hb)
+        return time() - mtime(hb) > l.stale_after
+    end
+    # No heartbeat file yet. Use dir age as fallback — tolerates the
+    # short acquisition window but still catches holders that died before
+    # the first heartbeat.
+    return time() - mtime(l.dir) > l.stale_after
+end
+
+"""
+    reclaim!(l)
+
+Forcefully remove `l.dir`. Callers must check `is_stale` first.
+Uses rename-then-rm so a concurrent reclaim attempt can't double-delete.
+"""
+function reclaim!(l::KeyLock)
+    dead = string(l.dir, ".dead.", getpid(), ".", rand(UInt32))
+    try
+        mv(l.dir, dead; force=false)
+    catch
+        return nothing  # someone else already reclaimed it
+    end
+    try
+        rm(dead; force=true, recursive=true)
+    catch
+    end
+    return nothing
+end
+
+"""
+    try_acquire(l) -> Bool
+
+Atomically attempt to take the lock. On failure, if the existing lock is
+stale, reclaim it once and retry.
+"""
+function try_acquire(l::KeyLock)::Bool
+    mkpath(dirname(l.dir))
+    if _mkdir_take(l)
+        return true
+    end
+    # Already held — check if stale
+    if is_stale(l)
+        reclaim!(l)
+        return _mkdir_take(l)
+    end
+    return false
+end
+
+function _mkdir_take(l::KeyLock)::Bool
+    try
+        mkdir(l.dir)
+    catch
+        return false
+    end
+    try
+        write(holder_path(l), l.holder)
+        touch(heartbeat_path(l))
+    catch
+        try
+            rm(l.dir; force=true, recursive=true)
+        catch
+        end
+        return false
+    end
+    return true
+end
+
+"""
+    release!(l)
+
+Remove the lock directory. Safe to call multiple times.
+"""
+function release!(l::KeyLock)
+    try
+        rm(l.dir; force=true, recursive=true)
+    catch
+    end
+    return nothing
+end
+
+"""
+    with_key_lock(f, l)
+
+Run `f()` while holding `l` and running a heartbeat task in the background.
+Returns `f()`'s value, or `nothing` if the lock could not be acquired.
+Releases the lock and stops the heartbeat task even if `f` throws.
+"""
+function with_key_lock(f::Function, l::KeyLock)
+    try_acquire(l) || return nothing
+    stop = Threads.Atomic{Bool}(false)
+    # Heartbeat loop sleeps in small chunks so `stop` is observed promptly
+    # at release — otherwise `wait(hb_task)` blocks for up to heartbeat_interval.
+    tick = 0.1
+    hb_task = Threads.@spawn begin
+        elapsed = 0.0
+        while !stop[]
+            sleep(tick)
+            stop[] && break
+            elapsed += tick
+            if elapsed >= l.heartbeat_interval
+                touch_heartbeat(l)
+                elapsed = 0.0
+            end
+        end
+    end
+    try
+        return f()
+    finally
+        stop[] = true
+        try
+            wait(hb_task)
+        catch
+        end
+        release!(l)
+    end
+end
+
+export KeyLock, try_acquire, release!, with_key_lock
+export holder_path, heartbeat_path, touch_heartbeat, is_stale, reclaim!

--- a/src/KeyLock.jl
+++ b/src/KeyLock.jl
@@ -25,15 +25,18 @@ struct KeyLock
     heartbeat_interval::Float64
 end
 
-function KeyLock(dir::AbstractString; stale_after::Real=600.0,
-                 heartbeat_interval::Real=60.0)
-    KeyLock(String(dir),
-            string(gethostname(), ":", getpid()),
-            Float64(stale_after),
-            Float64(heartbeat_interval))
+function KeyLock(
+    dir::AbstractString; stale_after::Real=600.0, heartbeat_interval::Real=60.0
+)
+    KeyLock(
+        String(dir),
+        string(gethostname(), ":", getpid()),
+        Float64(stale_after),
+        Float64(heartbeat_interval),
+    )
 end
 
-holder_path(l::KeyLock)    = joinpath(l.dir, "holder")
+holder_path(l::KeyLock) = joinpath(l.dir, "holder")
 heartbeat_path(l::KeyLock) = joinpath(l.dir, "heartbeat")
 
 """

--- a/src/Manifest.jl
+++ b/src/Manifest.jl
@@ -1,0 +1,108 @@
+# Manifest — rollup index of completed keys per stage (痛点 #6)
+#
+# FiniteTemperature.jl stat'd 3600 `.done` files per job (10 min). A Manifest
+# collapses that to a single JLD2 read — O(1) on full-done re-runs.
+
+using JLD2
+using ParamIO: DataKey, canonical
+
+"""
+    Manifest(stage, root, complete)
+
+Rollup index for a single stage under a vault root. `complete` holds the
+canonical string of every key known to be finished. Monotonic: once a key is
+added it is not removed (contract C5 in the ParallelManager spec).
+
+The on-disk form is `<root>/<stage>/manifest.jld2` with a single field
+`complete::Vector{String}`. Vector (not Set) is used for JLD2 portability;
+`load_manifest` rehydrates to a Set for O(1) lookup.
+"""
+mutable struct Manifest
+    stage::Symbol
+    root::String
+    complete::Set{String}
+end
+
+Manifest(stage::Symbol, root::AbstractString) =
+    Manifest(stage, String(root), Set{String}())
+
+"""
+    manifest_path(root, stage)
+
+Return `<root>/<stage>/manifest.jld2`.
+"""
+manifest_path(root::AbstractString, stage::Symbol) =
+    joinpath(String(root), String(stage), "manifest.jld2")
+
+"""
+    load_manifest(root, stage) -> Manifest
+
+Read `manifest.jld2` if present; otherwise return an empty Manifest.
+A corrupted manifest (read fails) is treated as empty — the worst case is
+re-running some keys, which is safe.
+"""
+function load_manifest(root::AbstractString, stage::Symbol)::Manifest
+    p = manifest_path(root, stage)
+    if !isfile(p)
+        return Manifest(stage, root)
+    end
+    try
+        data = JLD2.load(p)
+        items = get(data, "complete", String[])
+        return Manifest(stage, String(root), Set{String}(items))
+    catch
+        return Manifest(stage, String(root))
+    end
+end
+
+"""
+    save_manifest(m)
+
+Atomically write `m.complete` to disk. Uses `atomic_write` with a temp file
++ rename so a crashed master can't leave a half-written manifest.
+"""
+function save_manifest(m::Manifest)
+    p = manifest_path(m.root, m.stage)
+    items = sort!(collect(m.complete))
+    mkpath(dirname(p))
+    # JLD2 writes to a path, so we do the tmp + rename dance directly.
+    tmp = string(p, ".tmp.", getpid(), ".", rand(UInt32))
+    try
+        JLD2.jldsave(tmp; complete=items)
+        mv(tmp, p; force=true)
+    catch
+        isfile(tmp) && try
+            rm(tmp; force=true)
+        catch
+        end
+        rethrow()
+    end
+    return p
+end
+
+"""
+    add_complete!(m, key)
+
+Add `canonical(key)` to the in-memory complete set. Not persisted until
+`save_manifest` is called. Monotonic: no `remove_complete!`.
+"""
+add_complete!(m::Manifest, key::DataKey) = push!(m.complete, canonical(key))
+
+"""
+    is_complete(m, key) -> Bool
+
+True iff `key` is already in the manifest.
+"""
+is_complete(m::Manifest, key::DataKey) = canonical(key) in m.complete
+
+"""
+    todo_keys(m, keys) -> Vector{DataKey}
+
+Return the subset of `keys` that are not yet complete — the work list for
+the next `run!`. Full-done case returns an empty vector (for early skip).
+"""
+todo_keys(m::Manifest, keys::AbstractVector{DataKey}) =
+    [k for k in keys if !is_complete(m, k)]
+
+export Manifest, manifest_path, load_manifest, save_manifest
+export add_complete!, is_complete, todo_keys

--- a/src/Manifest.jl
+++ b/src/Manifest.jl
@@ -23,16 +23,16 @@ mutable struct Manifest
     complete::Set{String}
 end
 
-Manifest(stage::Symbol, root::AbstractString) =
-    Manifest(stage, String(root), Set{String}())
+Manifest(stage::Symbol, root::AbstractString) = Manifest(stage, String(root), Set{String}())
 
 """
     manifest_path(root, stage)
 
 Return `<root>/<stage>/manifest.jld2`.
 """
-manifest_path(root::AbstractString, stage::Symbol) =
+function manifest_path(root::AbstractString, stage::Symbol)
     joinpath(String(root), String(stage), "manifest.jld2")
+end
 
 """
     load_manifest(root, stage) -> Manifest
@@ -101,8 +101,9 @@ is_complete(m::Manifest, key::DataKey) = canonical(key) in m.complete
 Return the subset of `keys` that are not yet complete — the work list for
 the next `run!`. Full-done case returns an empty vector (for early skip).
 """
-todo_keys(m::Manifest, keys::AbstractVector{DataKey}) =
+function todo_keys(m::Manifest, keys::AbstractVector{DataKey})
     [k for k in keys if !is_complete(m, k)]
+end
 
 export Manifest, manifest_path, load_manifest, save_manifest
 export add_complete!, is_complete, todo_keys

--- a/src/ParallelManager.jl
+++ b/src/ParallelManager.jl
@@ -1,5 +1,16 @@
 module ParallelManager
 
-greet() = print("Hello World!")
+# Implementation is split across files. Each file is added as it gets implemented
+# in the todo sequence (see work/dev/HPCformat/todo/).
+#
+# Do NOT add a per-item `println` API anywhere in this module. Structured events
+# go through EventLog (JSONL) only. This is a structural answer to痛点 #7.
+
+include("AtomicIO.jl")
+include("EventLog.jl")
+include("Manifest.jl")
+include("KeyLock.jl")
+include("InitWorkers.jl")
+include("Run.jl")
 
 end # module ParallelManager

--- a/src/Run.jl
+++ b/src/Run.jl
@@ -22,8 +22,12 @@ struct RunOpts
     heartbeat_interval::Float64
 end
 
-function RunOpts(; workers::Symbol=:auto, max_attempts::Int=3,
-                 stale_after::Real=600.0, heartbeat_interval::Real=60.0)
+function RunOpts(;
+    workers::Symbol=:auto,
+    max_attempts::Int=3,
+    stale_after::Real=600.0,
+    heartbeat_interval::Real=60.0,
+)
     RunOpts(workers, max_attempts, Float64(stale_after), Float64(heartbeat_interval))
 end
 
@@ -35,8 +39,9 @@ Lives under the vault outdir, keyed by canonical(key), so multiple masters
 on the same vault agree on the location without touching DataVault internals.
 """
 function _key_lock_dir(vault::Vault, key::DataKey)
-    joinpath(vault.outdir, "locks", vault.spec.study.project_name,
-             vault.run, canonical(key))
+    joinpath(
+        vault.outdir, "locks", vault.spec.study.project_name, vault.run, canonical(key)
+    )
 end
 
 """
@@ -45,8 +50,9 @@ end
 Where the ParallelManager manifest file lives for this vault.
 One manifest per (project, run).
 """
-manifest_root(vault::Vault) =
+function manifest_root(vault::Vault)
     joinpath(vault.outdir, "manifest", vault.spec.study.project_name)
+end
 
 """
     load_manifest(vault) -> Manifest
@@ -77,8 +83,9 @@ Contract:
 
 Sequential execution; multi-master locking is added in todo 11.
 """
-function run!(work_fn::Function, vault::Vault, keys::AbstractVector{DataKey};
-              opts::RunOpts=RunOpts())
+function run!(
+    work_fn::Function, vault::Vault, keys::AbstractVector{DataKey}; opts::RunOpts=RunOpts()
+)
     stage = Symbol(vault.run)
     log = EventLog(joinpath(vault.outdir, "events.jsonl"))
 
@@ -91,8 +98,7 @@ function run!(work_fn::Function, vault::Vault, keys::AbstractVector{DataKey};
         return (stage=stage, done=0, err=0, skipped=length(keys), total=length(keys))
     end
 
-    log_event(log, :stage_start; stage=stage,
-              total=length(keys), todo=length(todo))
+    log_event(log, :stage_start; stage=stage, total=length(keys), todo=length(todo))
 
     n_done = 0
     n_err = 0
@@ -100,9 +106,11 @@ function run!(work_fn::Function, vault::Vault, keys::AbstractVector{DataKey};
     n_gave_up = 0
     for key in todo
         kstr = canonical(key)
-        klock = KeyLock(_key_lock_dir(vault, key);
-                        stale_after=opts.stale_after,
-                        heartbeat_interval=opts.heartbeat_interval)
+        klock = KeyLock(
+            _key_lock_dir(vault, key);
+            stale_after=opts.stale_after,
+            heartbeat_interval=opts.heartbeat_interval,
+        )
 
         outcome = with_key_lock(klock) do
             # Re-check after acquiring the lock — another master may have
@@ -134,12 +142,26 @@ function run!(work_fn::Function, vault::Vault, keys::AbstractVector{DataKey};
     # Persist the updated manifest once per stage end
     save_manifest(m)
 
-    log_event(log, :stage_done; stage=stage, total=length(keys),
-              done=n_done, err=n_err, busy=n_busy, gave_up=n_gave_up,
-              skipped=length(keys) - length(todo))
-    return (stage=stage, done=n_done, err=n_err, busy=n_busy,
-            gave_up=n_gave_up, skipped=length(keys) - length(todo),
-            total=length(keys))
+    log_event(
+        log,
+        :stage_done;
+        stage=stage,
+        total=length(keys),
+        done=n_done,
+        err=n_err,
+        busy=n_busy,
+        gave_up=n_gave_up,
+        skipped=length(keys) - length(todo),
+    )
+    return (
+        stage=stage,
+        done=n_done,
+        err=n_err,
+        busy=n_busy,
+        gave_up=n_gave_up,
+        skipped=length(keys) - length(todo),
+        total=length(keys),
+    )
 end
 
 """
@@ -150,8 +172,15 @@ Execute `work_fn(key)` up to `opts.max_attempts` times. Returns:
   :gave_up  — all attempts failed, final `:gave_up` event logged
   :error    — single-attempt config (`max_attempts == 1`) that failed once
 """
-function _run_one_with_retry!(work_fn, vault::Vault, key::DataKey, kstr::String,
-                              stage::Symbol, log::EventLog, opts::RunOpts)
+function _run_one_with_retry!(
+    work_fn,
+    vault::Vault,
+    key::DataKey,
+    kstr::String,
+    stage::Symbol,
+    log::EventLog,
+    opts::RunOpts,
+)
     last_err = nothing
     for attempt in 1:opts.max_attempts
         log_event(log, :key_start; stage=stage, key=kstr, attempt=attempt)
@@ -164,22 +193,22 @@ function _run_one_with_retry!(work_fn, vault::Vault, key::DataKey, kstr::String,
             )
             DataVault.save!(vault, key, payload)
             DataVault.mark_done!(vault, key)
-            log_event(log, :key_done; stage=stage, key=kstr,
-                      secs=time() - t0, attempt=attempt)
+            log_event(
+                log, :key_done; stage=stage, key=kstr, secs=time() - t0, attempt=attempt
+            )
             return :ok
         catch e
             last_err = sprint(showerror, e)
-            log_event(log, :error; stage=stage, key=kstr,
-                      attempt=attempt, err=last_err)
+            log_event(log, :error; stage=stage, key=kstr, attempt=attempt, err=last_err)
             if attempt < opts.max_attempts
-                log_event(log, :retry; stage=stage, key=kstr,
-                          next_attempt=attempt + 1)
+                log_event(log, :retry; stage=stage, key=kstr, next_attempt=attempt + 1)
                 sleep(0.1 * attempt)  # linear backoff
             end
         end
     end
-    log_event(log, :gave_up; stage=stage, key=kstr,
-              attempts=opts.max_attempts, err=last_err)
+    log_event(
+        log, :gave_up; stage=stage, key=kstr, attempts=opts.max_attempts, err=last_err
+    )
     return opts.max_attempts == 1 ? :error : :gave_up
 end
 

--- a/src/Run.jl
+++ b/src/Run.jl
@@ -1,0 +1,186 @@
+# Run — the facade that ties work_fn to Vault, Lock, Manifest, Log
+#
+# Evolution across todos:
+#   09: minimal (sequential, no manifest, no lock)
+#   10: + Manifest (early skip)
+#   11: + KeyLock (multi-master)
+#   12: + retry
+
+using DataVault
+using ParamIO: DataKey, canonical
+
+"""
+    RunOpts(; workers=:auto, max_attempts=1, stale_after=600.0,
+             heartbeat_interval=60.0)
+
+Execution options for `run!`.
+"""
+struct RunOpts
+    workers::Symbol
+    max_attempts::Int
+    stale_after::Float64
+    heartbeat_interval::Float64
+end
+
+function RunOpts(; workers::Symbol=:auto, max_attempts::Int=3,
+                 stale_after::Real=600.0, heartbeat_interval::Real=60.0)
+    RunOpts(workers, max_attempts, Float64(stale_after), Float64(heartbeat_interval))
+end
+
+"""
+    _key_lock_dir(vault, key) -> String
+
+Return the per-(vault.run, key) lock directory path.
+Lives under the vault outdir, keyed by canonical(key), so multiple masters
+on the same vault agree on the location without touching DataVault internals.
+"""
+function _key_lock_dir(vault::Vault, key::DataKey)
+    joinpath(vault.outdir, "locks", vault.spec.study.project_name,
+             vault.run, canonical(key))
+end
+
+"""
+    manifest_root(vault) -> String
+
+Where the ParallelManager manifest file lives for this vault.
+One manifest per (project, run).
+"""
+manifest_root(vault::Vault) =
+    joinpath(vault.outdir, "manifest", vault.spec.study.project_name)
+
+"""
+    load_manifest(vault) -> Manifest
+
+Convenience overload that reads the manifest for `vault.run` under this vault.
+"""
+load_manifest(vault::Vault) = load_manifest(manifest_root(vault), Symbol(vault.run))
+
+"""
+    run!(work_fn, vault, keys; opts=RunOpts()) -> NamedTuple
+
+Run `work_fn(key) -> Dict` for every `key` in `keys`, persisting through
+`vault`. Writes a structured JSONL event log at
+`joinpath(vault.outdir, "events.jsonl")`.
+
+Early skip (todo 10): on startup a stage-level Manifest is loaded. Keys
+already in the manifest are skipped — when all keys are done, the second
+run-through takes O(1) filesystem operations regardless of `length(keys)`.
+This is the answer to 痛点 #6 (3600-file rescan every job).
+
+Contract:
+- `work_fn` is expected to be a pure function: given a `DataKey`, return a
+  `Dict` payload to persist via `DataVault.save!`.
+- Exceptions in `work_fn` are caught and logged; the corresponding key's
+  `.done` file is not written, so re-runs will pick it up.
+- The stage label used for logging is `Symbol(vault.run)`.
+- Manifest is monotonic: saved at end-of-stage with every newly completed key.
+
+Sequential execution; multi-master locking is added in todo 11.
+"""
+function run!(work_fn::Function, vault::Vault, keys::AbstractVector{DataKey};
+              opts::RunOpts=RunOpts())
+    stage = Symbol(vault.run)
+    log = EventLog(joinpath(vault.outdir, "events.jsonl"))
+
+    # Early skip: load manifest, subtract completed keys
+    m = load_manifest(vault)
+    todo = todo_keys(m, collect(keys))
+
+    if isempty(todo)
+        log_event(log, :skip_complete; stage=stage, total=length(keys))
+        return (stage=stage, done=0, err=0, skipped=length(keys), total=length(keys))
+    end
+
+    log_event(log, :stage_start; stage=stage,
+              total=length(keys), todo=length(todo))
+
+    n_done = 0
+    n_err = 0
+    n_busy = 0
+    n_gave_up = 0
+    for key in todo
+        kstr = canonical(key)
+        klock = KeyLock(_key_lock_dir(vault, key);
+                        stale_after=opts.stale_after,
+                        heartbeat_interval=opts.heartbeat_interval)
+
+        outcome = with_key_lock(klock) do
+            # Re-check after acquiring the lock — another master may have
+            # finished this key between our manifest read and lock acquire.
+            if DataVault.is_done(vault, key)
+                return :already_done
+            end
+            DataVault.mark_running!(vault, key)
+            return _run_one_with_retry!(work_fn, vault, key, kstr, stage, log, opts)
+        end
+
+        if outcome === nothing
+            # Another master is running this key
+            log_event(log, :lock_busy; stage=stage, key=kstr)
+            n_busy += 1
+        elseif outcome === :already_done
+            add_complete!(m, key)
+        elseif outcome === :ok
+            add_complete!(m, key)
+            n_done += 1
+        elseif outcome === :gave_up
+            n_gave_up += 1
+            n_err += 1
+        else  # :error (single-attempt failure)
+            n_err += 1
+        end
+    end
+
+    # Persist the updated manifest once per stage end
+    save_manifest(m)
+
+    log_event(log, :stage_done; stage=stage, total=length(keys),
+              done=n_done, err=n_err, busy=n_busy, gave_up=n_gave_up,
+              skipped=length(keys) - length(todo))
+    return (stage=stage, done=n_done, err=n_err, busy=n_busy,
+            gave_up=n_gave_up, skipped=length(keys) - length(todo),
+            total=length(keys))
+end
+
+"""
+    _run_one_with_retry!(work_fn, vault, key, kstr, stage, log, opts) -> Symbol
+
+Execute `work_fn(key)` up to `opts.max_attempts` times. Returns:
+  :ok       — payload saved and mark_done! called
+  :gave_up  — all attempts failed, final `:gave_up` event logged
+  :error    — single-attempt config (`max_attempts == 1`) that failed once
+"""
+function _run_one_with_retry!(work_fn, vault::Vault, key::DataKey, kstr::String,
+                              stage::Symbol, log::EventLog, opts::RunOpts)
+    last_err = nothing
+    for attempt in 1:opts.max_attempts
+        log_event(log, :key_start; stage=stage, key=kstr, attempt=attempt)
+        t0 = time()
+        try
+            payload = work_fn(key)
+            payload isa Dict || error(
+                "work_fn must return a Dict (got $(typeof(payload))). " *
+                "Wrap scalars as e.g. Dict(\"value\" => x).",
+            )
+            DataVault.save!(vault, key, payload)
+            DataVault.mark_done!(vault, key)
+            log_event(log, :key_done; stage=stage, key=kstr,
+                      secs=time() - t0, attempt=attempt)
+            return :ok
+        catch e
+            last_err = sprint(showerror, e)
+            log_event(log, :error; stage=stage, key=kstr,
+                      attempt=attempt, err=last_err)
+            if attempt < opts.max_attempts
+                log_event(log, :retry; stage=stage, key=kstr,
+                          next_attempt=attempt + 1)
+                sleep(0.1 * attempt)  # linear backoff
+            end
+        end
+    end
+    log_event(log, :gave_up; stage=stage, key=kstr,
+              attempts=opts.max_attempts, err=last_err)
+    return opts.max_attempts == 1 ? :error : :gave_up
+end
+
+export RunOpts, run!, manifest_root, load_manifest

--- a/test/atomicio/test_atomicio.jl
+++ b/test/atomicio/test_atomicio.jl
@@ -1,0 +1,76 @@
+using ParallelManager, Test
+
+@testset "atomic_write: basic" begin
+    mktempdir() do dir
+        path = joinpath(dir, "sub", "data.txt")
+        atomic_write(path) do io
+            write(io, "hello")
+        end
+        @test isfile(path)
+        @test read(path, String) == "hello"
+        # No .tmp leftovers
+        @test all(!startswith(f, "data.txt.tmp") for f in readdir(joinpath(dir, "sub")))
+    end
+end
+
+@testset "atomic_write: overwrite" begin
+    mktempdir() do dir
+        path = joinpath(dir, "data.txt")
+        atomic_write(io -> write(io, "first"), path)
+        atomic_write(io -> write(io, "second"), path)
+        @test read(path, String) == "second"
+    end
+end
+
+@testset "atomic_write: exception leaves target untouched" begin
+    mktempdir() do dir
+        path = joinpath(dir, "data.txt")
+        atomic_write(io -> write(io, "original"), path)
+        @test_throws ErrorException atomic_write(path) do io
+            write(io, "partial")
+            error("boom")
+        end
+        @test read(path, String) == "original"
+        # tmp cleaned up
+        @test all(!startswith(f, "data.txt.tmp") for f in readdir(dir))
+    end
+end
+
+@testset "atomic_write: exception when target did not exist" begin
+    mktempdir() do dir
+        path = joinpath(dir, "data.txt")
+        @test_throws ErrorException atomic_write(path) do io
+            write(io, "partial")
+            error("boom")
+        end
+        @test !isfile(path)
+    end
+end
+
+@testset "atomic_touch" begin
+    mktempdir() do dir
+        path = joinpath(dir, "a", "b", ".done")
+        atomic_touch(path)
+        @test isfile(path)
+        @test filesize(path) == 0
+    end
+end
+
+@testset "atomic_write: concurrent writers produce some valid final content" begin
+    mktempdir() do dir
+        path = joinpath(dir, "data.txt")
+        N = 20
+        Threads.@threads for i in 1:N
+            atomic_write(path) do io
+                write(io, string("writer-", i))
+            end
+        end
+        @test isfile(path)
+        final = read(path, String)
+        @test startswith(final, "writer-")
+        # Some writer won; the content is complete (not truncated)
+        @test any(final == "writer-$i" for i in 1:N)
+        # No stray tmp files
+        @test all(!startswith(f, "data.txt.tmp") for f in readdir(dir))
+    end
+end

--- a/test/eventlog/test_eventlog.jl
+++ b/test/eventlog/test_eventlog.jl
@@ -1,0 +1,80 @@
+using ParallelManager, Test, JSON3
+
+@testset "EventLog: single write" begin
+    mktempdir() do dir
+        log = EventLog(joinpath(dir, "events.jsonl"))
+        log_event(log, :stage_start; stage="phase1", todo=10)
+        lines = readlines(log.path)
+        @test length(lines) == 1
+        rec = JSON3.read(lines[1])
+        @test rec.kind == "stage_start"
+        @test rec.stage == "phase1"
+        @test rec.todo == 10
+        @test haskey(rec, :ts)
+    end
+end
+
+@testset "EventLog: all standard event kinds" begin
+    mktempdir() do dir
+        log = EventLog(joinpath(dir, "events.jsonl"))
+        for k in (:stage_start, :stage_done, :key_start, :key_done,
+                  :lock_busy, :lock_reclaimed, :error, :gave_up, :retry,
+                  :skip_complete)
+            log_event(log, k; info="test")
+        end
+        lines = readlines(log.path)
+        @test length(lines) == 10
+        for line in lines
+            rec = JSON3.read(line)
+            @test haskey(rec, :kind)
+            @test haskey(rec, :ts)
+        end
+    end
+end
+
+@testset "EventLog: concurrent writers do not tear lines" begin
+    mktempdir() do dir
+        log = EventLog(joinpath(dir, "events.jsonl"))
+        N_tasks = 50
+        N_events_per_task = 40
+        tasks = Task[]
+        for tid in 1:N_tasks
+            let tid = tid
+                push!(tasks, Threads.@spawn begin
+                    for i in 1:N_events_per_task
+                        log_event(log, :key_done; tid=tid, i=i)
+                    end
+                end)
+            end
+        end
+        foreach(wait, tasks)
+
+        lines = readlines(log.path)
+        @test length(lines) == N_tasks * N_events_per_task
+        # Every line must be valid JSON
+        for line in lines
+            rec = JSON3.read(line)
+            @test haskey(rec, :tid)
+            @test haskey(rec, :i)
+        end
+    end
+end
+
+@testset "EventLog: parent directory auto-created" begin
+    mktempdir() do dir
+        log = EventLog(joinpath(dir, "deep", "nested", "events.jsonl"))
+        log_event(log, :stage_start)
+        @test isfile(log.path)
+    end
+end
+
+@testset "EventLog: no println API exported" begin
+    # Structural check: log_event is the only per-event API
+    names_exported = names(ParallelManager)
+    @test :log_event in names_exported
+    # No public function named `println_event`, `print_event`, etc.
+    for n in names_exported
+        s = String(n)
+        @test !occursin("println", s)
+    end
+end

--- a/test/eventlog/test_eventlog.jl
+++ b/test/eventlog/test_eventlog.jl
@@ -17,9 +17,18 @@ end
 @testset "EventLog: all standard event kinds" begin
     mktempdir() do dir
         log = EventLog(joinpath(dir, "events.jsonl"))
-        for k in (:stage_start, :stage_done, :key_start, :key_done,
-                  :lock_busy, :lock_reclaimed, :error, :gave_up, :retry,
-                  :skip_complete)
+        for k in (
+            :stage_start,
+            :stage_done,
+            :key_start,
+            :key_done,
+            :lock_busy,
+            :lock_reclaimed,
+            :error,
+            :gave_up,
+            :retry,
+            :skip_complete,
+        )
             log_event(log, k; info="test")
         end
         lines = readlines(log.path)

--- a/test/init_workers/test_init_workers.jl
+++ b/test/init_workers/test_init_workers.jl
@@ -1,0 +1,62 @@
+using ParallelManager, Test
+using LinearAlgebra
+
+@testset "detect_mode: no SLURM" begin
+    # Strip SLURM env for the duration of this test
+    withenv("SLURM_JOB_ID" => nothing) do
+        m = detect_mode()
+        @test m in (:threads, :sequential)
+    end
+end
+
+@testset "detect_mode: SLURM_JOB_ID present" begin
+    withenv("SLURM_JOB_ID" => "12345") do
+        @test detect_mode() == :slurm
+    end
+end
+
+@testset "init_workers!: :sequential is a no-op" begin
+    withenv("SLURM_JOB_ID" => nothing) do
+        m = init_workers!(mode=:sequential, master_blas=1, verbose=false)
+        @test m == :sequential
+        @test BLAS.get_num_threads() == 1
+    end
+end
+
+@testset "init_workers!: :threads sets BLAS" begin
+    m = init_workers!(mode=:threads, master_blas=1, verbose=false)
+    @test m == :threads
+    @test BLAS.get_num_threads() == 1
+end
+
+@testset "init_workers!: idempotent on re-call" begin
+    init_workers!(mode=:sequential, master_blas=2, verbose=false)
+    init_workers!(mode=:sequential, master_blas=2, verbose=false)
+    @test BLAS.get_num_threads() == 2
+    init_workers!(mode=:sequential, master_blas=1, verbose=false)  # restore
+end
+
+@testset "init_workers!: :auto with no SLURM" begin
+    withenv("SLURM_JOB_ID" => nothing) do
+        m = init_workers!(mode=:auto, verbose=false)
+        @test m in (:threads, :sequential)
+    end
+end
+
+@testset "init_workers!: unknown mode errors" begin
+    @test_throws ErrorException init_workers!(mode=:nonsense, verbose=false)
+end
+
+@testset "init_workers!: :slurm env reading (no actual addprocs)" begin
+    # We cannot truly spawn a SLURM worker here. Instead, set
+    # JULIA_SLURM_N_WORKERS=0 so addprocs is skipped but the code path runs.
+    withenv("SLURM_JOB_ID" => "1",
+            "JULIA_SLURM_N_WORKERS" => "0",
+            "JULIA_WORKER_CPUS" => "2") do
+        m = init_workers!(mode=:slurm, verbose=false)
+        @test m == :slurm
+        # Master BLAS was set (worker count is 0, no @everywhere)
+        @test BLAS.get_num_threads() >= 1
+    end
+    init_workers!(mode=:sequential, master_blas=1, verbose=false)  # restore
+end

--- a/test/init_workers/test_init_workers.jl
+++ b/test/init_workers/test_init_workers.jl
@@ -50,9 +50,9 @@ end
 @testset "init_workers!: :slurm env reading (no actual addprocs)" begin
     # We cannot truly spawn a SLURM worker here. Instead, set
     # JULIA_SLURM_N_WORKERS=0 so addprocs is skipped but the code path runs.
-    withenv("SLURM_JOB_ID" => "1",
-            "JULIA_SLURM_N_WORKERS" => "0",
-            "JULIA_WORKER_CPUS" => "2") do
+    withenv(
+        "SLURM_JOB_ID" => "1", "JULIA_SLURM_N_WORKERS" => "0", "JULIA_WORKER_CPUS" => "2"
+    ) do
         m = init_workers!(mode=:slurm, verbose=false)
         @test m == :slurm
         # Master BLAS was set (worker count is 0, no @everywhere)

--- a/test/keylock/test_keylock_basic.jl
+++ b/test/keylock/test_keylock_basic.jl
@@ -81,19 +81,21 @@ end
         max_inside = Threads.Atomic{Int}(0)
         tasks = Task[]
         for _ in 1:100
-            push!(tasks, Threads.@spawn begin
-                l = KeyLock(lockdir)
-                with_key_lock(l) do
-                    current = Threads.atomic_add!(inside, 1) + 1
-                    while true
-                        m = max_inside[]
-                        current <= m && break
-                        Threads.atomic_cas!(max_inside, m, current) == m && break
+            push!(
+                tasks, Threads.@spawn begin
+                    l = KeyLock(lockdir)
+                    with_key_lock(l) do
+                        current = Threads.atomic_add!(inside, 1) + 1
+                        while true
+                            m = max_inside[]
+                            current <= m && break
+                            Threads.atomic_cas!(max_inside, m, current) == m && break
+                        end
+                        sleep(0.001)  # hold long enough to expose races
+                        Threads.atomic_sub!(inside, 1)
                     end
-                    sleep(0.001)  # hold long enough to expose races
-                    Threads.atomic_sub!(inside, 1)
                 end
-            end)
+            )
         end
         foreach(wait, tasks)
         @test max_inside[] == 1

--- a/test/keylock/test_keylock_basic.jl
+++ b/test/keylock/test_keylock_basic.jl
@@ -1,0 +1,101 @@
+using ParallelManager, Test
+
+@testset "KeyLock: first acquire succeeds" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k1.lock"))
+        @test try_acquire(l) == true
+        @test isdir(l.dir)
+        @test isfile(holder_path(l))
+        holder = read(holder_path(l), String)
+        @test occursin(":", holder)  # "host:pid"
+    end
+end
+
+@testset "KeyLock: second acquire on same dir fails" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k1.lock"))
+        @test try_acquire(l) == true
+        l2 = KeyLock(joinpath(dir, "k1.lock"))
+        @test try_acquire(l2) == false
+    end
+end
+
+@testset "KeyLock: release then re-acquire" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k1.lock"))
+        @test try_acquire(l) == true
+        release!(l)
+        @test !isdir(l.dir)
+        @test try_acquire(l) == true
+    end
+end
+
+@testset "KeyLock: release is idempotent" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k1.lock"))
+        release!(l)  # no-op when not held
+        @test !isdir(l.dir)
+    end
+end
+
+@testset "with_key_lock: returns f() when acquired" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k1.lock"))
+        result = with_key_lock(l) do
+            return 42
+        end
+        @test result == 42
+        @test !isdir(l.dir)  # released after block
+    end
+end
+
+@testset "with_key_lock: returns nothing when busy" begin
+    mktempdir() do dir
+        l1 = KeyLock(joinpath(dir, "k1.lock"))
+        @test try_acquire(l1) == true  # permanently held for this test
+        l2 = KeyLock(joinpath(dir, "k1.lock"))
+        result = with_key_lock(l2) do
+            return 42
+        end
+        @test result === nothing
+        release!(l1)
+    end
+end
+
+@testset "with_key_lock: releases on exception" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k1.lock"))
+        @test_throws ErrorException with_key_lock(l) do
+            error("boom")
+        end
+        @test !isdir(l.dir)
+    end
+end
+
+@testset "KeyLock: mutual exclusion under contention" begin
+    # The right invariant: at any single instant, at most one task is inside
+    # the critical section. Sequential release/acquire is allowed.
+    mktempdir() do dir
+        lockdir = joinpath(dir, "race.lock")
+        inside = Threads.Atomic{Int}(0)
+        max_inside = Threads.Atomic{Int}(0)
+        tasks = Task[]
+        for _ in 1:100
+            push!(tasks, Threads.@spawn begin
+                l = KeyLock(lockdir)
+                with_key_lock(l) do
+                    current = Threads.atomic_add!(inside, 1) + 1
+                    while true
+                        m = max_inside[]
+                        current <= m && break
+                        Threads.atomic_cas!(max_inside, m, current) == m && break
+                    end
+                    sleep(0.001)  # hold long enough to expose races
+                    Threads.atomic_sub!(inside, 1)
+                end
+            end)
+        end
+        foreach(wait, tasks)
+        @test max_inside[] == 1
+    end
+end

--- a/test/keylock/test_keylock_heartbeat.jl
+++ b/test/keylock/test_keylock_heartbeat.jl
@@ -1,0 +1,136 @@
+using ParallelManager, Test
+
+@testset "KeyLock: heartbeat file created on acquire" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k.lock"))
+        @test try_acquire(l)
+        @test isfile(heartbeat_path(l))
+        release!(l)
+    end
+end
+
+@testset "KeyLock: touch_heartbeat updates mtime" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k.lock"))
+        @test try_acquire(l)
+        t0 = mtime(heartbeat_path(l))
+        sleep(1.2)
+        touch_heartbeat(l)
+        t1 = mtime(heartbeat_path(l))
+        @test t1 > t0
+        release!(l)
+    end
+end
+
+@testset "KeyLock: is_stale detects old heartbeat" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k.lock"); stale_after=0.1)
+        @test try_acquire(l)
+        @test !is_stale(l)
+        sleep(0.3)
+        @test is_stale(l)
+        release!(l)
+    end
+end
+
+@testset "KeyLock: stale lock reclaimed on next try_acquire" begin
+    mktempdir() do dir
+        # Simulate a dead master: grab lock, then don't release
+        l_dead = KeyLock(joinpath(dir, "k.lock"); stale_after=0.1)
+        @test try_acquire(l_dead)  # leave held
+
+        sleep(0.3)  # heartbeat now stale
+
+        # A new master comes in with short stale_after
+        l_new = KeyLock(joinpath(dir, "k.lock"); stale_after=0.1)
+        @test try_acquire(l_new) == true  # reclaims and re-takes
+        release!(l_new)
+    end
+end
+
+@testset "KeyLock: is_stale false for missing lock dir" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k.lock"); stale_after=0.1)
+        @test is_stale(l)  # no heartbeat file → stale
+    end
+end
+
+@testset "with_key_lock: heartbeat task runs in background" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k.lock");
+                    stale_after=10.0, heartbeat_interval=0.2)
+        mtimes = Float64[]
+        with_key_lock(l) do
+            push!(mtimes, mtime(heartbeat_path(l)))
+            sleep(0.6)
+            push!(mtimes, mtime(heartbeat_path(l)))
+        end
+        @test mtimes[2] > mtimes[1]
+    end
+end
+
+@testset "with_key_lock: heartbeat task stops after release" begin
+    mktempdir() do dir
+        l = KeyLock(joinpath(dir, "k.lock"); heartbeat_interval=0.1)
+        with_key_lock(l) do
+            sleep(0.1)
+        end
+        # Lock dir should be gone
+        @test !isdir(l.dir)
+        # Give heartbeat task a chance to notice the stop flag
+        sleep(0.3)
+        # No stray heartbeat touches recreating files
+        @test !isfile(heartbeat_path(l))
+    end
+end
+
+@testset "KeyLock: reclaim race — two contenders, one wins" begin
+    mktempdir() do dir
+        lockdir = joinpath(dir, "k.lock")
+        # Plant a stale lock
+        l_dead = KeyLock(lockdir; stale_after=0.05)
+        @test try_acquire(l_dead)
+        sleep(0.2)  # make it stale
+
+        # Two concurrent reclaim attempts
+        winners = Threads.Atomic{Int}(0)
+        tasks = [Threads.@spawn begin
+            l = KeyLock(lockdir; stale_after=0.05)
+            if try_acquire(l)
+                Threads.atomic_add!(winners, 1)
+                sleep(0.1)
+                release!(l)
+            end
+        end for _ in 1:10]
+        foreach(wait, tasks)
+        # Exactly one wins at the moment of contention; some may win sequentially
+        # after release (that's OK). The key property is: no simultaneous holders.
+        @test winners[] >= 1
+    end
+end
+
+@testset "KeyLock: mutual exclusion still holds with heartbeat" begin
+    mktempdir() do dir
+        lockdir = joinpath(dir, "k.lock")
+        inside = Threads.Atomic{Int}(0)
+        max_inside = Threads.Atomic{Int}(0)
+        tasks = Task[]
+        for _ in 1:50
+            push!(tasks, Threads.@spawn begin
+                l = KeyLock(lockdir; heartbeat_interval=10.0)
+                with_key_lock(l) do
+                    current = Threads.atomic_add!(inside, 1) + 1
+                    while true
+                        m = max_inside[]
+                        current <= m && break
+                        Threads.atomic_cas!(max_inside, m, current) == m && break
+                    end
+                    sleep(0.001)
+                    Threads.atomic_sub!(inside, 1)
+                end
+            end)
+        end
+        foreach(wait, tasks)
+        @test max_inside[] == 1
+    end
+end

--- a/test/keylock/test_keylock_heartbeat.jl
+++ b/test/keylock/test_keylock_heartbeat.jl
@@ -57,8 +57,7 @@ end
 
 @testset "with_key_lock: heartbeat task runs in background" begin
     mktempdir() do dir
-        l = KeyLock(joinpath(dir, "k.lock");
-                    stale_after=10.0, heartbeat_interval=0.2)
+        l = KeyLock(joinpath(dir, "k.lock"); stale_after=10.0, heartbeat_interval=0.2)
         mtimes = Float64[]
         with_key_lock(l) do
             push!(mtimes, mtime(heartbeat_path(l)))
@@ -116,19 +115,21 @@ end
         max_inside = Threads.Atomic{Int}(0)
         tasks = Task[]
         for _ in 1:50
-            push!(tasks, Threads.@spawn begin
-                l = KeyLock(lockdir; heartbeat_interval=10.0)
-                with_key_lock(l) do
-                    current = Threads.atomic_add!(inside, 1) + 1
-                    while true
-                        m = max_inside[]
-                        current <= m && break
-                        Threads.atomic_cas!(max_inside, m, current) == m && break
+            push!(
+                tasks, Threads.@spawn begin
+                    l = KeyLock(lockdir; heartbeat_interval=10.0)
+                    with_key_lock(l) do
+                        current = Threads.atomic_add!(inside, 1) + 1
+                        while true
+                            m = max_inside[]
+                            current <= m && break
+                            Threads.atomic_cas!(max_inside, m, current) == m && break
+                        end
+                        sleep(0.001)
+                        Threads.atomic_sub!(inside, 1)
                     end
-                    sleep(0.001)
-                    Threads.atomic_sub!(inside, 1)
                 end
-            end)
+            )
         end
         foreach(wait, tasks)
         @test max_inside[] == 1

--- a/test/manifest/test_manifest.jl
+++ b/test/manifest/test_manifest.jl
@@ -1,0 +1,101 @@
+using ParallelManager, Test, ParamIO
+
+mkkey(params; sample=0) = DataKey(Dict{String,Any}(params...), sample)
+
+@testset "Manifest: empty when absent" begin
+    mktempdir() do dir
+        m = load_manifest(dir, :phase1)
+        @test m.stage == :phase1
+        @test isempty(m.complete)
+    end
+end
+
+@testset "Manifest: add, save, load round-trip" begin
+    mktempdir() do dir
+        m = load_manifest(dir, :phase1)
+        k1 = mkkey(["N" => 8, "J" => 1.0]; sample=1)
+        k2 = mkkey(["N" => 8, "J" => 2.0]; sample=1)
+        add_complete!(m, k1)
+        add_complete!(m, k2)
+        save_manifest(m)
+
+        @test isfile(manifest_path(dir, :phase1))
+
+        m2 = load_manifest(dir, :phase1)
+        @test is_complete(m2, k1)
+        @test is_complete(m2, k2)
+        @test length(m2.complete) == 2
+    end
+end
+
+@testset "Manifest: todo_keys subtracts complete set" begin
+    mktempdir() do dir
+        m = load_manifest(dir, :phase1)
+        k1 = mkkey(["N" => 8]; sample=1)
+        k2 = mkkey(["N" => 16]; sample=1)
+        k3 = mkkey(["N" => 32]; sample=1)
+        add_complete!(m, k1)
+        add_complete!(m, k2)
+        todo = todo_keys(m, [k1, k2, k3])
+        @test length(todo) == 1
+        @test todo[1] == k3
+    end
+end
+
+@testset "Manifest: all done -> todo_keys empty" begin
+    mktempdir() do dir
+        m = load_manifest(dir, :phase1)
+        keys = [mkkey(["N" => n]; sample=1) for n in (4, 8, 16)]
+        for k in keys
+            add_complete!(m, k)
+        end
+        @test isempty(todo_keys(m, keys))
+    end
+end
+
+@testset "Manifest: corrupted file treated as empty" begin
+    mktempdir() do dir
+        p = manifest_path(dir, :phase1)
+        mkpath(dirname(p))
+        write(p, "not a jld2 file")
+        m = load_manifest(dir, :phase1)
+        @test isempty(m.complete)
+    end
+end
+
+@testset "Manifest: monotonic (no remove API)" begin
+    # Structural check: there is no `remove_complete!` exported
+    names_exported = names(ParallelManager)
+    @test !(:remove_complete! in names_exported)
+    @test !(:delete_complete! in names_exported)
+end
+
+@testset "Manifest: bench 3600 keys load+todo < 500ms" begin
+    mktempdir() do dir
+        m = load_manifest(dir, :phase1)
+        keys = [mkkey(["N" => i]; sample=1) for i in 1:3600]
+        for k in keys
+            add_complete!(m, k)
+        end
+        save_manifest(m)
+
+        # Measure second-time load + todo_keys
+        t0 = time()
+        m2 = load_manifest(dir, :phase1)
+        td = todo_keys(m2, keys)
+        elapsed = time() - t0
+        @test isempty(td)
+        @test elapsed < 0.5  # 500ms loose budget; full target is <100ms (todo 04)
+        @info "Manifest bench" n_keys=3600 elapsed_s=elapsed
+    end
+end
+
+@testset "Manifest: field order independence via canonical" begin
+    mktempdir() do dir
+        m = load_manifest(dir, :phase1)
+        k_a = DataKey(Dict{String,Any}("N" => 8, "J" => 1.0), 1)
+        k_b = DataKey(Dict{String,Any}("J" => 1.0, "N" => 8), 1)
+        add_complete!(m, k_a)
+        @test is_complete(m, k_b)
+    end
+end

--- a/test/run/fixtures/study.toml
+++ b/test/run/fixtures/study.toml
@@ -1,0 +1,11 @@
+[study]
+project_name  = "pm_test"
+total_samples = 1
+outdir        = "out"
+
+[datavault]
+path_keys = ["N", "J"]
+
+[[paramsets]]
+N = [4, 8]
+J = [0.5, 1.0]

--- a/test/run/test_run_keylock.jl
+++ b/test/run/test_run_keylock.jl
@@ -1,0 +1,129 @@
+using ParallelManager, Test, DataVault, ParamIO, JSON3
+
+const FIXTURE_CFG_L = joinpath(@__DIR__, "fixtures", "study.toml")
+
+function with_vault_l(f; run::AbstractString="phase1")
+    outdir = mktempdir()
+    try
+        v = DataVault.Vault(FIXTURE_CFG_L; run=run, outdir=outdir)
+        f(v, outdir)
+    finally
+        rm(outdir; recursive=true, force=true)
+    end
+end
+
+allk(v) = ParamIO.expand(v.spec)
+
+@testset "run! + keylock: each key processed exactly once across masters" begin
+    with_vault_l() do v, outdir
+        keys = allk(v)
+        # Per-key counter: how many times work_fn was invoked for this key.
+        # The lock guarantees "at most one invocation at a time per key" and
+        # the is_done re-check ensures no duplicate invocation across masters.
+        calls = Dict{String,Threads.Atomic{Int}}()
+        for k in keys
+            calls[canonical(k)] = Threads.Atomic{Int}(0)
+        end
+        work_fn = k -> begin
+            Threads.atomic_add!(calls[canonical(k)], 1)
+            sleep(0.01)
+            return Dict{String,Any}("x" => 1)
+        end
+
+        # 4 masters racing on the same vault
+        tasks = [Threads.@spawn(run!(work_fn, v, keys;
+                                      opts=RunOpts(heartbeat_interval=10.0)))
+                 for _ in 1:4]
+        foreach(wait, tasks)
+
+        for k in keys
+            @test DataVault.is_done(v, k)
+            # work_fn called exactly once per key, regardless of 4 masters
+            @test calls[canonical(k)][] == 1
+        end
+    end
+end
+
+@testset "run! + keylock: :lock_busy event appears under contention" begin
+    with_vault_l() do v, outdir
+        keys = allk(v)
+        work_fn = k -> (sleep(0.02); Dict{String,Any}("x" => 1))
+        tasks = [Threads.@spawn(run!(work_fn, v, keys;
+                                      opts=RunOpts(heartbeat_interval=10.0)))
+                 for _ in 1:4]
+        foreach(wait, tasks)
+
+        lines = readlines(joinpath(outdir, "events.jsonl"))
+        kinds = [JSON3.read(l).kind for l in lines]
+        # Either some locks were busy, or one master finished everything so
+        # fast the others saw :skip_complete. Both are acceptable outcomes.
+        @test ("lock_busy" in kinds) || ("skip_complete" in kinds)
+        # And all keys are done
+        for k in keys
+            @test DataVault.is_done(v, k)
+        end
+    end
+end
+
+@testset "run! + retry: eventual success" begin
+    with_vault_l() do v, outdir
+        keys = allk(v)[1:1]
+        attempts = Ref(0)
+        work_fn = k -> begin
+            attempts[] += 1
+            if attempts[] < 3
+                error("transient")
+            end
+            return Dict{String,Any}("x" => attempts[])
+        end
+        result = run!(work_fn, v, keys; opts=RunOpts(max_attempts=5))
+        @test result.done == 1
+        @test result.err == 0
+        @test attempts[] == 3
+        @test DataVault.is_done(v, keys[1])
+
+        lines = readlines(joinpath(outdir, "events.jsonl"))
+        kinds = [JSON3.read(l).kind for l in lines]
+        @test "retry" in kinds
+        @test !("gave_up" in kinds)
+    end
+end
+
+@testset "run! + retry: gave_up after max_attempts" begin
+    with_vault_l() do v, outdir
+        keys = allk(v)[1:1]
+        attempts = Ref(0)
+        work_fn = k -> begin
+            attempts[] += 1
+            error("permanent")
+        end
+        result = run!(work_fn, v, keys; opts=RunOpts(max_attempts=3))
+        @test attempts[] == 3
+        @test result.gave_up == 1
+        @test !DataVault.is_done(v, keys[1])
+
+        # Manifest does NOT include this key
+        m = load_manifest(v)
+        @test !is_complete(m, keys[1])
+
+        lines = readlines(joinpath(outdir, "events.jsonl"))
+        kinds = [JSON3.read(l).kind for l in lines]
+        @test "gave_up" in kinds
+    end
+end
+
+@testset "run! + retry: re-run picks up gave_up key" begin
+    with_vault_l() do v, outdir
+        keys = allk(v)[1:1]
+        # First run: permanent failure
+        run!(k -> error("x"), v, keys; opts=RunOpts(max_attempts=2))
+        @test !DataVault.is_done(v, keys[1])
+
+        # Second run with working work_fn: should process the key
+        counter = Ref(0)
+        run!(k -> (counter[] += 1; Dict{String,Any}("x" => 1)), v, keys;
+             opts=RunOpts(max_attempts=2))
+        @test counter[] == 1
+        @test DataVault.is_done(v, keys[1])
+    end
+end

--- a/test/run/test_run_keylock.jl
+++ b/test/run/test_run_keylock.jl
@@ -31,9 +31,10 @@ allk(v) = ParamIO.expand(v.spec)
         end
 
         # 4 masters racing on the same vault
-        tasks = [Threads.@spawn(run!(work_fn, v, keys;
-                                      opts=RunOpts(heartbeat_interval=10.0)))
-                 for _ in 1:4]
+        tasks = [
+            Threads.@spawn(run!(work_fn, v, keys; opts=RunOpts(heartbeat_interval=10.0)))
+            for _ in 1:4
+        ]
         foreach(wait, tasks)
 
         for k in keys
@@ -48,9 +49,10 @@ end
     with_vault_l() do v, outdir
         keys = allk(v)
         work_fn = k -> (sleep(0.02); Dict{String,Any}("x" => 1))
-        tasks = [Threads.@spawn(run!(work_fn, v, keys;
-                                      opts=RunOpts(heartbeat_interval=10.0)))
-                 for _ in 1:4]
+        tasks = [
+            Threads.@spawn(run!(work_fn, v, keys; opts=RunOpts(heartbeat_interval=10.0)))
+            for _ in 1:4
+        ]
         foreach(wait, tasks)
 
         lines = readlines(joinpath(outdir, "events.jsonl"))
@@ -121,8 +123,12 @@ end
 
         # Second run with working work_fn: should process the key
         counter = Ref(0)
-        run!(k -> (counter[] += 1; Dict{String,Any}("x" => 1)), v, keys;
-             opts=RunOpts(max_attempts=2))
+        run!(
+            k -> (counter[] += 1; Dict{String,Any}("x" => 1)),
+            v,
+            keys;
+            opts=RunOpts(max_attempts=2),
+        )
         @test counter[] == 1
         @test DataVault.is_done(v, keys[1])
     end

--- a/test/run/test_run_manifest.jl
+++ b/test/run/test_run_manifest.jl
@@ -1,0 +1,120 @@
+using ParallelManager, Test, DataVault, ParamIO, JSON3
+
+const FIXTURE_CFG_M = joinpath(@__DIR__, "fixtures", "study.toml")
+
+function with_vault_m(f; run::AbstractString="phase1")
+    outdir = mktempdir()
+    try
+        v = DataVault.Vault(FIXTURE_CFG_M; run=run, outdir=outdir)
+        f(v, outdir)
+    finally
+        rm(outdir; recursive=true, force=true)
+    end
+end
+
+allkeys(v::DataVault.Vault) = ParamIO.expand(v.spec)
+
+@testset "run! + manifest: first run creates manifest" begin
+    with_vault_m() do v, outdir
+        keys = allkeys(v)
+        result = run!(key -> Dict{String,Any}("x" => 1), v, keys)
+        @test result.done == length(keys)
+
+        mpath = manifest_path(manifest_root(v), Symbol(v.run))
+        @test isfile(mpath)
+
+        m = load_manifest(v)
+        @test length(m.complete) == length(keys)
+        for k in keys
+            @test is_complete(m, k)
+        end
+    end
+end
+
+@testset "run! + manifest: second run is early-skip" begin
+    with_vault_m() do v, outdir
+        keys = allkeys(v)
+        counter = Ref(0)
+        work_fn = _ -> (counter[] += 1; Dict{String,Any}("x" => 1))
+
+        run!(work_fn, v, keys)
+        first_count = counter[]
+        @test first_count == length(keys)
+
+        t0 = time()
+        result2 = run!(work_fn, v, keys)
+        elapsed = time() - t0
+        @test counter[] == first_count  # work_fn NOT called again
+        @test result2.skipped == length(keys)
+        @test result2.done == 0
+        @test elapsed < 1.0  # early skip is fast
+
+        # events.jsonl has :skip_complete
+        lines = readlines(joinpath(outdir, "events.jsonl"))
+        kinds = [JSON3.read(l).kind for l in lines]
+        @test "skip_complete" in kinds
+    end
+end
+
+@testset "run! + manifest: adding a new key only runs that one" begin
+    with_vault_m() do v, outdir
+        keys = allkeys(v)
+        run!(key -> Dict{String,Any}("x" => 1), v, keys)
+
+        counter = Ref(0)
+        # Simulate a new key added later (fake — DataKey with a new param)
+        new_key = DataKey(Dict{String,Any}("N" => 99, "J" => 9.9), 1)
+        all_keys_plus = vcat(keys, new_key)
+
+        work_fn = k -> begin
+            counter[] += 1
+            Dict{String,Any}("x" => 2)
+        end
+        result = run!(work_fn, v, all_keys_plus)
+        @test counter[] == 1  # only the new key
+        @test result.done == 1
+        @test result.skipped == length(keys)
+    end
+end
+
+@testset "run! + manifest: failed key not persisted" begin
+    with_vault_m() do v, outdir
+        keys = allkeys(v)
+        bad = keys[1]
+        work_fn = k -> k == bad ? error("nope") : Dict{String,Any}("x" => 1)
+        run!(work_fn, v, keys)
+
+        m = load_manifest(v)
+        @test !is_complete(m, bad)
+        @test length(m.complete) == length(keys) - 1
+
+        # On re-run the bad key is retried
+        counter = Ref(0)
+        work_fn2 = k -> (counter[] += 1; Dict{String,Any}("x" => 2))
+        result2 = run!(work_fn2, v, keys)
+        @test counter[] == 1  # only the previously-bad key
+        @test result2.done == 1
+    end
+end
+
+@testset "run! + manifest: 3600 key early-skip bench" begin
+    with_vault_m(; run="bench") do v, outdir
+        # Fabricate 3600 keys (don't actually run work_fn 3600 times with full
+        # DataVault save; instead preload the manifest directly and measure skip)
+        keys = [DataKey(Dict{String,Any}("N" => i, "J" => 1.0), 1) for i in 1:3600]
+        m = load_manifest(v)
+        for k in keys
+            add_complete!(m, k)
+        end
+        save_manifest(m)
+
+        # Second call should be near-instant
+        t0 = time()
+        result = run!(k -> Dict{String,Any}("x" => 1), v, keys)
+        elapsed = time() - t0
+        @test result.skipped == 3600
+        @test result.done == 0
+        @test elapsed < 1.0  # target: full-done run finishes in <1s
+        @info "3600-key early-skip bench" elapsed_s=elapsed
+    end
+end

--- a/test/run/test_run_minimal.jl
+++ b/test/run/test_run_minimal.jl
@@ -1,0 +1,91 @@
+using ParallelManager, Test, DataVault, ParamIO, JSON3
+
+const FIXTURE_CFG = joinpath(@__DIR__, "fixtures", "study.toml")
+
+function with_run_vault(f; run::AbstractString="phase1")
+    outdir = mktempdir()
+    try
+        v = DataVault.Vault(FIXTURE_CFG; run=run, outdir=outdir)
+        f(v, outdir)
+    finally
+        rm(outdir; recursive=true, force=true)
+    end
+end
+
+function all_keys(v::DataVault.Vault)
+    ParamIO.expand(v.spec)
+end
+
+@testset "run! minimal: happy path" begin
+    with_run_vault() do v, outdir
+        keys = all_keys(v)
+        @test length(keys) > 0
+
+        counter = Ref(0)
+        work_fn = key -> begin
+            counter[] += 1
+            return Dict{String,Any}("result" => counter[], "N" => key.params["N"])
+        end
+
+        result = run!(work_fn, v, keys)
+        @test result.total == length(keys)
+        @test result.done == length(keys)
+        @test result.err == 0
+
+        # Every key is marked done
+        for k in keys
+            @test DataVault.is_done(v, k)
+        end
+
+        # Events are recorded
+        events_path = joinpath(outdir, "events.jsonl")
+        @test isfile(events_path)
+        lines = readlines(events_path)
+        kinds = [JSON3.read(l).kind for l in lines]
+        @test "stage_start" in kinds
+        @test "stage_done" in kinds
+        @test count(==("key_start"), kinds) == length(keys)
+        @test count(==("key_done"), kinds) == length(keys)
+    end
+end
+
+@testset "run! minimal: exception in one key, others complete" begin
+    with_run_vault() do v, outdir
+        keys = all_keys(v)
+        bad_key = keys[2]
+        work_fn = key -> begin
+            key == bad_key && error("nope")
+            return Dict{String,Any}("ok" => true)
+        end
+
+        result = run!(work_fn, v, keys)
+        @test result.done == length(keys) - 1
+        @test result.err == 1
+        @test !DataVault.is_done(v, bad_key)
+        for k in keys
+            k == bad_key && continue
+            @test DataVault.is_done(v, k)
+        end
+
+        lines = readlines(joinpath(outdir, "events.jsonl"))
+        kinds = [JSON3.read(l).kind for l in lines]
+        @test "error" in kinds
+    end
+end
+
+@testset "run! minimal: non-Dict payload raises" begin
+    with_run_vault() do v, outdir
+        keys = all_keys(v)[1:1]
+        result = run!(key -> 42, v, keys)
+        @test result.err == 1
+        @test result.done == 0
+    end
+end
+
+@testset "run! minimal: no per-key println noise" begin
+    # Structural: there must be no println call in Run.jl per-key path.
+    src = read(joinpath(pkgdir(ParallelManager), "src", "Run.jl"), String)
+    # Strip comments/docstrings to count real println calls
+    code_only = replace(src, r"#[^\n]*" => "")
+    @test !occursin("println(", code_only)
+end

--- a/test/run/test_run_minimal.jl
+++ b/test/run/test_run_minimal.jl
@@ -22,10 +22,11 @@ end
         @test length(keys) > 0
 
         counter = Ref(0)
-        work_fn = key -> begin
-            counter[] += 1
-            return Dict{String,Any}("result" => counter[], "N" => key.params["N"])
-        end
+        work_fn =
+            key -> begin
+                counter[] += 1
+                return Dict{String,Any}("result" => counter[], "N" => key.params["N"])
+            end
 
         result = run!(work_fn, v, keys)
         @test result.total == length(keys)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 ENV["GKSwstype"] = "100"
 
 using ParallelManager, Test
-const dirs = []
+const dirs = ["atomicio", "eventlog", "manifest", "keylock", "init_workers", "run"]
 
 const FIG_BASE = joinpath(pkgdir(ParallelManager), "docs", "src", "assets")
 const PATHS = Dict()


### PR DESCRIPTION
## Summary

Layered HPC workflow runtime built from an empty template to answer 痛点 #6〜#9 observed in FiniteTemperature.jl. All five modules + a unified `run!` facade land in this PR.

| Module | Role | Answers |
| --- | --- | --- |
| `AtomicIO` | NFS-safe `atomic_write` / `atomic_touch` | #8 half-written files |
| `EventLog` | Structured JSONL event log, single-write atomic lines for multi-process append safety | #7 300MB println logs |
| `Manifest` | Stage-level rollup of `canonical(key)` strings; early-skip on full-done runs | #6 3600-file rescan |
| `KeyLock` | mkdir advisory lock + heartbeat + stale reclaim | #8 dead sample recovery, #9 multi-master contention |
| `InitWorkers` | `init_workers!` — unified `:auto`/`:sequential`/`:threads`/`:distributed`/`:slurm` worker bootstrap, absorbing the existing `HybridInit` pattern | Uniform entry for all parallel modes |
| `Run` | `run!(work_fn, vault, keys; opts)` facade with retry + lock_busy/gave_up events | Ties everything to DataVault |

### `run!` contract

- `work_fn` is a pure function `(DataKey) -> Dict` — IO / logging / locking live in the runtime, not in user code.
- Exceptions in `work_fn` do not mark keys done, so re-runs pick them up.
- Manifest is **monotonic**: keys are only added, never removed.
- Multi-master safe: 4 processes on the same vault root → zero duplicate executions.
- Kill-recovery: next `run!` auto-reclaims stale locks via heartbeat mtime.

## Dependencies

- **`ParamIO`**: pinned via `[sources]` to the `feat/canonical` branch (https://github.com/sotashimozono/ParamIO.jl/pull/5). The `rev` pin must be removed from `Project.toml` after that PR merges.
- **`DataVault`**: `main`, unchanged.

## Test plan

- [x] `Pkg.test()` — 4202 tests pass in ~22s across:
  - `atomicio/` — atomic write, exception cleanup, overwrite, concurrent writers
  - `eventlog/` — JSON roundtrip, concurrent 2000-event writes, no per-item println in exports
  - `manifest/` — save/load roundtrip, todo_keys, 3600-key bench, corrupted file
  - `keylock/` — basic mutex, heartbeat, stale reclaim, mutual exclusion under contention
  - `init_workers/` — `:auto`/`:sequential`/`:threads`/`:slurm` env reading
  - `run/` — minimal, manifest early-skip, keylock multi-master, retry, gave_up
- [x] Local integration: 3600-key skip bench — warm re-run **3.5ms** (was 10min in FiniteTemperature.jl, 180,000× faster)
- [x] Local integration: 4-master × 20-key multi_master.jl — zero duplicates, 43 lock_busy, no half-writes
- [x] Local integration: SIGKILL mid-run + recovery — 10/10 keys auto-reclaimed
- [ ] SLURM real-machine run: deferred to HPC cluster (see `work/dev/HPCformat/integration/results/slurm_smoke.md`)

## Bugs fixed during implementation

- **KeyLock race on fresh acquisition**: `is_stale` returned true while a new holder was still writing the heartbeat file, causing reclaim of healthy locks. Fixed by falling back to lock-dir mtime when heartbeat is missing.
- **EventLog torn lines**: `println(io, line)` split into two writes, allowing concurrent masters to interleave JSON characters. Fixed by a single `write(io, line_with_newline)` call — relies on POSIX `O_APPEND` atomicity for writes < `PIPE_BUF`.
- **Heartbeat task hang**: `sleep(heartbeat_interval)` blocked `wait(hb_task)` in the `with_key_lock` finally block for up to 60s. Fixed by sleeping in 0.1s chunks and checking the stop flag each tick.