### PR TITLE
Fix Codecov badge link in README.md

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParallelManager"
 uuid = "be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![Julia](https://img.shields.io/badge/julia-v1.12+-9558b2.svg)](https://julialang.org)
 [![Code Style: Blue](https://img.shields.io/badge/Code%20Style-Blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
-<a id="badge-top"></a>
-[![codecov](https://codecov.io/gh/sotashimozono/template.jl/graph/badge.svg?token=Q3oEEiz9A2)](https://codecov.io/gh/sotashimozono/template.jl)
+[![codecov](https://codecov.io/gh/sotashimozono/ParallelManager.jl/graph/badge.svg?token=0kGBejbpL8)](https://codecov.io/gh/sotashimozono/ParallelManager.jl)
 [![Build Status](https://github.com/sotashimozono/ParallelManager.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/sotashimozono/ParallelManager.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
Updated Codecov badge to point to ParallelManager.jl repository.

<!--
The two sections "Proposed Changes" and "Usage or Results" below are
extracted by .github/scripts/build_release_notes.py and inserted into
the GitHub Release notes when a new tag is published. Treat them as the
PR's contribution to the changelog: keep them readable, focused, and
self-contained. Renaming or removing those headings will break the
release-notes builder.
-->

## Description

Fixed: #  (if any)

## Type of Change

- [ ] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [x] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)

## Proposed Changes

<!-- This section is included in the release notes. -->

what did you change?

- write here

## Usage or Results

<!-- This section is included in the release notes. -->

```julia
# Example or verification script

```

## check list
- [x] test駆動をしたか
- [x] Project.tomlのバージョンを上げたか
