### PR TITLE
InitWorkers: fix withenv scope for SlurmManager + addprocs (:slurm)

### DIFF
--- a/src/InitWorkers.jl
+++ b/src/InitWorkers.jl
@@ -90,11 +90,31 @@ function init_workers!(;
         )
         if n_workers > 0 && nprocs() == 1
             project = dirname(Base.active_project())
-            mgr = withenv("SLURM_NTASKS" => string(n_workers)) do
-                SlurmClusterManager.SlurmManager(; launch_timeout=Float64(launch_timeout))
-            end
-            # Export JULIA_WORKER_TIMEOUT for the srun-spawned workers.
-            withenv("JULIA_WORKER_TIMEOUT" => string(worker_timeout)) do
+            # BOTH the `SlurmManager()` construction AND the
+            # `addprocs(mgr)` call must live inside the SAME
+            # `withenv("SLURM_NTASKS" => string(n_workers))` block.
+            #
+            # `SlurmClusterManager` reads `ENV["SLURM_NTASKS"]` lazily
+            # inside `launch(mgr, ...)` (i.e. during `addprocs`), not
+            # at constructor time.  If `addprocs` runs outside the
+            # withenv, SlurmManager sees the job-level `SLURM_NTASKS`
+            # (= master + workers) and tries to spawn one more worker
+            # than there is a task slot for.  The extra worker never
+            # arrives, the master blocks forever in `addprocs`, and
+            # in stdout this looks like "no output after precompile
+            # ok".  See FiniteTemperature.jl's reference
+            # `src/Parallel/Slurm.jl::init_slurm_workers!` for the
+            # working pattern we are porting here.
+            #
+            # `JULIA_WORKER_TIMEOUT` is nested inside the same block so
+            # srun-spawned workers inherit a longer handshake window.
+            withenv(
+                "SLURM_NTASKS" => string(n_workers),
+                "JULIA_WORKER_TIMEOUT" => string(worker_timeout),
+            ) do
+                mgr = SlurmClusterManager.SlurmManager(;
+                    launch_timeout=Float64(launch_timeout)
+                )
                 addprocs(mgr; exeflags="--project=$project")
             end
         end


### PR DESCRIPTION
## Summary

- In the `:slurm` branch of `init_workers!`, move the `addprocs(mgr; ...)` call INSIDE the `withenv("SLURM_NTASKS" => string(n_workers))` block, together with the `SlurmManager()` constructor.
- Fold `JULIA_WORKER_TIMEOUT` into the same multi-variable `withenv` call, matching FT's reference pattern.

## Why

`SlurmClusterManager` reads `ENV[\"SLURM_NTASKS\"]` lazily inside `launch(mgr, ...)` (which is called by `addprocs`), not at constructor time.  The previous layout constructed `SlurmManager` inside the withenv block but ran `addprocs(mgr)` outside it, so SlurmManager saw the job-level `SLURM_NTASKS` (= master + workers) and tried to `srun` one more worker than the allocation has a task slot for.  The extra worker never arrived, `addprocs` blocked forever, and the caller's stdout went silent after `precompile ok`.

Observed on ISSP System B `i8cpu` phase1 (128 tasks / 127 workers / 8 nodes): batch log 2874171 shows the banner + `precompile ok` and nothing else — master hung inside `addprocs(mgr)`.

The working reference (already in production on ISSP) is [FiniteTemperature.jl's `src/Parallel/Slurm.jl::init_slurm_workers!`](https://github.com/sotashimozono/FiniteTemperature.jl/blob/main/src/Parallel/Slurm.jl), which wraps both the constructor and `addprocs` in a single `withenv` block.  This PR makes `ParallelManager.init_workers!(:slurm)` match that layout exactly.

## Test plan

- [x] Code review: diff matches FT's proven pattern 1:1 structurally.
- [ ] ISSP i8cpu re-run of `ThermalEquilibrium/phase1.toml` with 127 workers (user will re-run after submodule bump).