### PR TITLE
feat: try-finally + .running heartbeat + merge_and_save_manifest!

### DIFF
--- a/src/Manifest.jl
+++ b/src/Manifest.jl
@@ -68,8 +68,7 @@ mutable struct Manifest
     complete::Set{String}
 end
 
-Manifest(stage::Symbol, root::AbstractString) =
-    Manifest(stage, String(root), Set{String}())
+Manifest(stage::Symbol, root::AbstractString) = Manifest(stage, String(root), Set{String}())
 
 """
     manifest_path(root, stage) -> String

--- a/src/Manifest.jl
+++ b/src/Manifest.jl
@@ -176,5 +176,24 @@ function todo_keys(m::Manifest, keys::AbstractVector{DataKey})
     [k for k in keys if !is_complete(m, k)]
 end
 
-export Manifest, manifest_path, load_manifest, save_manifest
+"""
+    merge_and_save_manifest!(m) -> String
+
+Reload the on-disk manifest, merge its completed keys into `m`, then
+atomically persist. This prevents the "last writer wins" problem when
+multiple masters call `save_manifest` concurrently — without the merge,
+each master would overwrite the others' newly completed keys.
+
+There is a small TOCTOU window between the `load_manifest` and the
+`save_manifest`; in the worst case a concurrent saver's keys are not
+included in this write, but they will be re-processed on the next
+invocation (safe due to `is_done` re-check inside [`KeyLock`](@ref)).
+"""
+function merge_and_save_manifest!(m::Manifest)
+    on_disk = load_manifest(m.root, m.stage)
+    union!(m.complete, on_disk.complete)
+    save_manifest(m)
+end
+
+export Manifest, manifest_path, load_manifest, save_manifest, merge_and_save_manifest!
 export add_complete!, is_complete, todo_keys

--- a/src/Run.jl
+++ b/src/Run.jl
@@ -179,8 +179,9 @@ function run!(
         end
     end
 
-    # Persist the updated manifest once per stage end
-    save_manifest(m)
+    # Persist the updated manifest, merging with on-disk state so that
+    # concurrent masters don't overwrite each other's completed keys.
+    merge_and_save_manifest!(m)
 
     log_event(
         log,
@@ -239,7 +240,32 @@ function _run_one_with_lock!(
             return :already_done
         end
         DataVault.mark_running!(vault, key)
-        return _run_one_with_retry!(work_fn, vault, key, kstr, stage, log, opts)
+        # Background task: update .running heartbeat at the same interval
+        # as the KeyLock heartbeat so cleanup_stale can detect live jobs.
+        running_stop = Threads.Atomic{Bool}(false)
+        running_hb = Threads.@spawn begin
+            tick = 0.1
+            elapsed = 0.0
+            while !running_stop[]
+                sleep(tick)
+                running_stop[] && break
+                elapsed += tick
+                if elapsed >= opts.heartbeat_interval
+                    DataVault.touch_running!(vault, key)
+                    elapsed = 0.0
+                end
+            end
+        end
+        try
+            return _run_one_with_retry!(work_fn, vault, key, kstr, stage, log, opts)
+        finally
+            running_stop[] = true
+            try
+                wait(running_hb)
+            catch
+            end
+            DataVault.clear_running!(vault, key)
+        end
     end
 
     if outcome === nothing


### PR DESCRIPTION
## Summary
- `_run_one_with_lock!` に try-finally 追加: 失敗時に `.running` ファイルが孤立する問題を修正
- `.running` heartbeat タスク追加: KeyLock と同じ間隔で `touch_running!` を呼び、`cleanup_stale` が活きたジョブを識別可能に
- `merge_and_save_manifest!` 追加: 10+ master 同時完了時の last-writer-wins によるマニフェスト消失を防止

## Dependencies
- DataVault.jl v0.4.1 (sotashimozono/DataVault.jl#10) の `clear_running!`, `touch_running!` が必要

## Test plan
- [x] 既存 4203 テスト全 pass
- [x] 4-master race test (`test_run_keylock.jl`) pass
- [x] retry/gave_up test pass (`.running` が finally で清掃されることを確認)