### PR TITLE
feat: stop_flag, run_loop!, verify_workers!, per-master EventLog, CI matrix

### DIFF
--- a/.github/ci/env_distributed_2.toml
+++ b/.github/ci/env_distributed_2.toml
@@ -1,0 +1,6 @@
+# Env 3: 2 worker processes via addprocs — exercises pmap path
+[env]
+mode = "distributed"
+n_workers = 2
+n_masters = 1
+test_dirs = ["run"]

--- a/.github/ci/env_distributed_4.toml
+++ b/.github/ci/env_distributed_4.toml
@@ -1,0 +1,6 @@
+# Env 4: 4 worker processes via addprocs — cross-process lock contention
+[env]
+mode = "distributed"
+n_workers = 4
+n_masters = 1
+test_dirs = ["run"]

--- a/.github/ci/env_sequential.toml
+++ b/.github/ci/env_sequential.toml
@@ -1,0 +1,6 @@
+# Env 1: basic correctness — single process, single thread
+[env]
+mode = "sequential"
+n_workers = 0
+n_masters = 1
+test_dirs = ["atomicio", "eventlog", "manifest", "keylock", "init_workers", "run"]

--- a/.github/ci/env_stress.toml
+++ b/.github/ci/env_stress.toml
@@ -1,0 +1,6 @@
+# Env 5: 10 master stress test — lock contention + manifest merge race
+[env]
+mode = "threaded"
+n_workers = 0
+n_masters = 10
+test_dirs = ["run", "keylock"]

--- a/.github/ci/env_threaded.toml
+++ b/.github/ci/env_threaded.toml
@@ -1,0 +1,6 @@
+# Env 2: thread-parallel multi-master (Threads.@spawn based races)
+[env]
+mode = "threaded"
+n_workers = 0
+n_masters = 4
+test_dirs = ["atomicio", "eventlog", "manifest", "keylock", "init_workers", "run"]

--- a/.github/ci/runner.jl
+++ b/.github/ci/runner.jl
@@ -15,7 +15,9 @@ test_dirs = env["test_dirs"]
 
 println("=" ^ 60)
 println("  CI Environment: $(ARGS[1])")
-println("  mode=$mode  workers=$n_workers  masters=$n_masters  threads=$(Threads.nthreads())")
+println(
+    "  mode=$mode  workers=$n_workers  masters=$n_masters  threads=$(Threads.nthreads())"
+)
 println("=" ^ 60)
 
 # Export n_masters so test code can scale Threads.@spawn accordingly

--- a/.github/ci/runner.jl
+++ b/.github/ci/runner.jl
@@ -1,0 +1,64 @@
+#!/usr/bin/env julia
+# .github/ci/runner.jl — TOML 設定に基づいてテスト環境を構築・実行
+#
+# Usage:
+#   julia --project=. --threads=4 .github/ci/runner.jl .github/ci/env_threaded.toml
+
+using TOML, Test
+
+cfg = TOML.parsefile(ARGS[1])
+env = cfg["env"]
+mode = env["mode"]
+n_workers = get(env, "n_workers", 0)
+n_masters = get(env, "n_masters", 1)
+test_dirs = env["test_dirs"]
+
+println("=" ^ 60)
+println("  CI Environment: $(ARGS[1])")
+println("  mode=$mode  workers=$n_workers  masters=$n_masters  threads=$(Threads.nthreads())")
+println("=" ^ 60)
+
+# Export n_masters so test code can scale Threads.@spawn accordingly
+ENV["PM_TEST_N_MASTERS"] = string(n_masters)
+
+# Launch Distributed workers when mode == "distributed"
+using Distributed  # always load; needed for nprocs() etc. in tests
+if mode == "distributed" && n_workers > 0
+    project = dirname(Base.active_project())
+    addprocs(n_workers; exeflags="--project=$project")
+    @everywhere using ParallelManager, DataVault, ParamIO
+    println("  Workers launched: $(workers())")
+end
+
+# Load the package (must come after addprocs so @everywhere sees it)
+using ParallelManager
+
+# Run test files from the specified directories
+@testset "ParallelManager ($mode, m=$(n_masters), w=$(n_workers))" begin
+    for dir in test_dirs
+        dirpath = joinpath(pkgdir(ParallelManager), "test", dir)
+        if !isdir(dirpath)
+            @warn "Test directory not found: $dirpath"
+            continue
+        end
+        files = sort(
+            filter(f -> startswith(f, "test_") && endswith(f, ".jl"), readdir(dirpath))
+        )
+        if isempty(files)
+            @warn "No test files found in $dirpath"
+            continue
+        end
+        for f in files
+            @testset "$dir/$f" begin
+                filepath = joinpath(dirpath, f)
+                println("  Including $filepath")
+                @time include(filepath)
+            end
+        end
+    end
+end
+
+# Clean up workers
+if nprocs() > 1
+    rmprocs(workers())
+end

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,26 +7,45 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.env_name }} - Julia ${{ matrix.version }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+        include:
+          - env_name: sequential
+            env_file: .github/ci/env_sequential.toml
+            julia_threads: 1
+            version: '1'
+          - env_name: threaded
+            env_file: .github/ci/env_threaded.toml
+            julia_threads: 4
+            version: '1'
+          - env_name: distributed-2
+            env_file: .github/ci/env_distributed_2.toml
+            julia_threads: 1
+            version: '1'
+          - env_name: distributed-4
+            env_file: .github/ci/env_distributed_4.toml
+            julia_threads: 1
+            version: '1'
+          - env_name: stress
+            env_file: .github/ci/env_stress.toml
+            julia_threads: 8
+            version: '1'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - name: Run tests (${{ matrix.env_name }})
+        run: |
+          julia --project=. --threads=${{ matrix.julia_threads }} \
+            .github/ci/runner.jl ${{ matrix.env_file }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v6
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParallelManager"
 uuid = "be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -18,7 +18,7 @@ SlurmClusterManager = "c82cd089-7bf7-41d7-976b-6b5d413cbe0a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
-DataVault = {rev = "main", url = "https://github.com/sotashimozono/DataVault.jl.git"}
+DataVault = {path = "/home/souta/work/Vault/infra/DataVault.jl"}
 ParamIO = {rev = "feat/canonical", url = "https://github.com/sotashimozono/ParamIO.jl.git"}
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ SlurmClusterManager = "c82cd089-7bf7-41d7-976b-6b5d413cbe0a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
-DataVault = {path = "/home/souta/work/Vault/infra/DataVault.jl"}
+DataVault = {rev = "main", url = "https://github.com/sotashimozono/DataVault.jl.git"}
 ParamIO = {rev = "feat/canonical", url = "https://github.com/sotashimozono/ParamIO.jl.git"}
 
 [compat]

--- a/src/EventLog.jl
+++ b/src/EventLog.jl
@@ -101,4 +101,31 @@ function log_event(log::EventLog, kind::Symbol; kwargs...)
     return nothing
 end
 
-export EventLog, log_event
+"""
+    merge_event_logs(dir; output="events_merged.jsonl") -> String
+
+Merge all per-master event log files (`events_*.jsonl`) in `dir` into a
+single sorted file. Returns the output path.
+
+Each master writes to its own `events_<host>_<pid>.jsonl`; this function
+collects and sorts all lines by their `ts` field for post-hoc analysis.
+"""
+function merge_event_logs(dir::AbstractString; output::String="events_merged.jsonl")
+    logs = filter(readdir(dir)) do f
+        startswith(f, "events_") && endswith(f, ".jsonl") && f != output
+    end
+    all_lines = String[]
+    for f in logs
+        append!(all_lines, readlines(joinpath(dir, f)))
+    end
+    sort!(all_lines; by=l -> JSON3.read(l).ts)
+    outpath = joinpath(dir, output)
+    open(outpath, "w") do io
+        for l in all_lines
+            println(io, l)
+        end
+    end
+    return outpath
+end
+
+export EventLog, log_event, merge_event_logs

--- a/src/InitWorkers.jl
+++ b/src/InitWorkers.jl
@@ -7,6 +7,7 @@
 
 using Distributed
 using LinearAlgebra
+using Printf
 using SlurmClusterManager
 
 """
@@ -73,7 +74,10 @@ function init_workers!(;
             end
         end
         _apply_blas(master_blas, worker_blas)
-        verbose && _log_init("distributed", n_workers, master_blas, worker_blas)
+        if verbose
+            _log_init("distributed", n_workers, master_blas, worker_blas)
+            verify_workers!()
+        end
         return :distributed
 
     elseif actual == :slurm
@@ -114,7 +118,10 @@ function init_workers!(;
             end
         end
         _apply_blas(master_blas, worker_blas)
-        verbose && _log_init("slurm", n_workers, master_blas, worker_blas)
+        if verbose
+            _log_init("slurm", n_workers, master_blas, worker_blas)
+            verify_workers!()
+        end
         return :slurm
 
     else
@@ -164,4 +171,48 @@ function _log_init(mode::String, n_workers::Int, master_blas::Int, worker_blas::
     return nothing
 end
 
-export init_workers!, detect_mode
+"""
+    verify_workers!()
+
+Probe each Distributed worker for hostname, Julia threads, BLAS threads,
+and CPU affinity. Prints a summary table and emits a `@warn` if any
+worker has `BLAS.get_num_threads() > 1` (a common cause of OpenBLAS
+segfaults in multi-process Julia).
+
+Ported from FiniteTemperature.jl `Parallel/Slurm.jl::print_worker_identities`.
+"""
+function verify_workers!()
+    nprocs() > 1 || return nothing
+    println("\n--- Worker verification ---")
+    futures = [
+        @spawnat p begin
+            cpuset = "N/A"
+            try
+                for line in eachline("/proc/self/status")
+                    if startswith(line, "Cpus_allowed_list:")
+                        cpuset = strip(split(line, ":")[2])
+                        break
+                    end
+                end
+            catch
+            end
+            (myid(), gethostname(), Threads.nthreads(), BLAS.get_num_threads(), cpuset)
+        end for p in workers()
+    ]
+
+    for f in futures
+        pid, host, nth, blas, cpuset = fetch(f)
+        @printf(
+            "  worker %d  host=%-12s  threads=%-3d  blas=%-3d  cpus=%s\n",
+            pid, host, nth, blas, cpuset
+        )
+        if blas > 1
+            @warn "Worker $pid: BLAS threads=$blas > 1 — OpenBLAS segfault risk"
+        end
+    end
+    println()
+    flush(stdout)
+    return nothing
+end
+
+export init_workers!, detect_mode, verify_workers!

--- a/src/InitWorkers.jl
+++ b/src/InitWorkers.jl
@@ -204,7 +204,11 @@ function verify_workers!()
         pid, host, nth, blas, cpuset = fetch(f)
         @printf(
             "  worker %d  host=%-12s  threads=%-3d  blas=%-3d  cpus=%s\n",
-            pid, host, nth, blas, cpuset
+            pid,
+            host,
+            nth,
+            blas,
+            cpuset
         )
         if blas > 1
             @warn "Worker $pid: BLAS threads=$blas > 1 — OpenBLAS segfault risk"

--- a/src/Run.jl
+++ b/src/Run.jl
@@ -152,7 +152,8 @@ function run!(
     work_fn::Function, vault::Vault, keys::AbstractVector{DataKey}; opts::RunOpts=RunOpts()
 )
     stage = Symbol(vault.run)
-    log = EventLog(joinpath(vault.outdir, "events.jsonl"))
+    log_name = "events_$(gethostname())_$(getpid()).jsonl"
+    log = EventLog(joinpath(vault.outdir, log_name))
 
     # Early skip: load manifest, subtract completed keys
     m = load_manifest(vault)

--- a/src/Run.jl
+++ b/src/Run.jl
@@ -17,7 +17,7 @@ using ParamIO: DataKey, canonical
 
 """
     RunOpts(; workers=:auto, max_attempts=3, stale_after=600.0,
-             heartbeat_interval=60.0)
+             heartbeat_interval=60.0, stop_flag=nothing)
 
 Execution options for [`run!`](@ref).
 
@@ -32,11 +32,18 @@ Execution options for [`run!`](@ref).
   reclaim a held lock as stale. Passed through to [`KeyLock`](@ref).
 - `heartbeat_interval::Float64 = 60.0` — how often the per-lock heartbeat
   task refreshes its `heartbeat` file. Must be `<` `stale_after`.
+- `stop_flag::Union{String,Nothing} = nothing` — path to a sentinel file.
+  When `isfile(stop_flag)` becomes true, [`run!`](@ref) and
+  [`run_loop!`](@ref) stop dispatching new keys and return early. This is
+  the infra equivalent of FiniteTemperature.jl's `STOP_NOW_\$JOB_ID`
+  mechanism, typically created by a SIGUSR1 signal handler in the batch
+  script 60 s before Slurm kills the job.
 
 # Example
 
 ```julia
-opts = RunOpts(max_attempts=5, stale_after=900.0, heartbeat_interval=30.0)
+opts = RunOpts(max_attempts=5, stale_after=900.0, heartbeat_interval=30.0,
+               stop_flag="/path/to/STOP_NOW_12345")
 ParallelManager.run!(work_fn, vault, keys; opts)
 ```
 """
@@ -45,6 +52,7 @@ struct RunOpts
     max_attempts::Int
     stale_after::Float64
     heartbeat_interval::Float64
+    stop_flag::Union{String,Nothing}
 end
 
 function RunOpts(;
@@ -52,9 +60,16 @@ function RunOpts(;
     max_attempts::Int=3,
     stale_after::Real=600.0,
     heartbeat_interval::Real=60.0,
+    stop_flag::Union{String,Nothing}=nothing,
 )
-    RunOpts(workers, max_attempts, Float64(stale_after), Float64(heartbeat_interval))
+    RunOpts(
+        workers, max_attempts, Float64(stale_after), Float64(heartbeat_interval), stop_flag
+    )
 end
+
+# Internal: check if the stop flag has been raised.
+_is_stopped(opts::RunOpts)::Bool =
+    opts.stop_flag !== nothing && isfile(opts.stop_flag)
 
 # Internal: per-(vault.run, key) lock directory path, keyed by
 # `canonical(key)` so multiple masters on the same vault agree on the
@@ -163,6 +178,7 @@ function run!(
     n_err = 0
     n_busy = 0
     n_gave_up = 0
+    n_stop = 0
     for (key, outcome) in outcomes
         if outcome === :lock_busy
             n_busy += 1
@@ -171,6 +187,8 @@ function run!(
         elseif outcome === :ok
             add_complete!(m, key)
             n_done += 1
+        elseif outcome === :stop
+            n_stop += 1
         elseif outcome === :gave_up
             n_gave_up += 1
             n_err += 1
@@ -192,6 +210,7 @@ function run!(
         err=n_err,
         busy=n_busy,
         gave_up=n_gave_up,
+        stop=n_stop,
         skipped=length(keys) - length(todo),
     )
     return (
@@ -200,6 +219,7 @@ function run!(
         err=n_err,
         busy=n_busy,
         gave_up=n_gave_up,
+        stop=n_stop,
         skipped=length(keys) - length(todo),
         total=length(keys),
     )
@@ -219,6 +239,7 @@ Outcome symbols:
 - `:ok`           — `work_fn` succeeded and `mark_done!` was called.
 - `:error`        — single-attempt failure (`opts.max_attempts == 1`).
 - `:gave_up`      — all `opts.max_attempts` attempts failed.
+- `:stop`         — stop flag detected before work started.
 """
 function _run_one_with_lock!(
     work_fn::Function,
@@ -229,6 +250,13 @@ function _run_one_with_lock!(
     opts::RunOpts,
 )
     kstr = canonical(key)
+
+    # Early exit if stop flag has been raised (checked by both sequential
+    # and pmap paths, so each worker can bail independently).
+    if _is_stopped(opts)
+        return (key, :stop)
+    end
+
     klock = KeyLock(
         _key_lock_dir(vault, key);
         stale_after=opts.stale_after,
@@ -286,7 +314,14 @@ function _run_sequential!(
     log::EventLog,
     opts::RunOpts,
 )
-    return [_run_one_with_lock!(work_fn, vault, key, stage, log, opts) for key in todo]
+    results = Vector{Tuple{DataKey,Symbol}}()
+    for key in todo
+        if _is_stopped(opts)
+            break
+        end
+        push!(results, _run_one_with_lock!(work_fn, vault, key, stage, log, opts))
+    end
+    return results
 end
 
 """
@@ -382,4 +417,46 @@ function _run_one_with_retry!(
     return opts.max_attempts == 1 ? :error : :gave_up
 end
 
-export RunOpts, run!, manifest_root, load_manifest
+"""
+    run_loop!(work_fn, vault, keys; opts=RunOpts(),
+              max_empty_rounds=3, idle_sleep=30.0)
+
+Work-stealing loop that repeatedly calls [`run!`](@ref) until there is no
+more work to do. This is the infra equivalent of FiniteTemperature.jl's
+`_work_loop` driver.
+
+The loop exits when:
+- `max_empty_rounds` consecutive rounds produce zero new completions, or
+- `opts.stop_flag` is raised (graceful shutdown).
+
+Default parameters (`max_empty_rounds=3`, `idle_sleep=30.0`) are the
+battle-tested values from FiniteTemperature.jl.
+"""
+function run_loop!(
+    work_fn::Function,
+    vault::Vault,
+    keys::AbstractVector{DataKey};
+    opts::RunOpts=RunOpts(),
+    max_empty_rounds::Int=3,
+    idle_sleep::Float64=30.0,
+)
+    empty_count = 0
+    while true
+        if _is_stopped(opts)
+            break
+        end
+        result = run!(work_fn, vault, keys; opts=opts)
+        if result.done > 0
+            empty_count = 0
+            continue
+        end
+        empty_count += 1
+        if empty_count >= max_empty_rounds
+            break
+        end
+        sleep(idle_sleep)
+    end
+    return nothing
+end
+
+export RunOpts, run!, run_loop!, manifest_root, load_manifest

--- a/src/Run.jl
+++ b/src/Run.jl
@@ -68,8 +68,7 @@ function RunOpts(;
 end
 
 # Internal: check if the stop flag has been raised.
-_is_stopped(opts::RunOpts)::Bool =
-    opts.stop_flag !== nothing && isfile(opts.stop_flag)
+_is_stopped(opts::RunOpts)::Bool = opts.stop_flag !== nothing && isfile(opts.stop_flag)
 
 # Internal: per-(vault.run, key) lock directory path, keyed by
 # `canonical(key)` so multiple masters on the same vault agree on the

--- a/test/manifest/test_manifest.jl
+++ b/test/manifest/test_manifest.jl
@@ -99,3 +99,30 @@ end
         @test is_complete(m, k_b)
     end
 end
+
+@testset "merge_and_save_manifest!: merges on-disk + in-memory" begin
+    mktempdir() do dir
+        ka = mkkey(["N" => 4, "J" => 0.5])
+        kb = mkkey(["N" => 4, "J" => 1.0])
+        kc = mkkey(["N" => 8, "J" => 0.5])
+
+        # Master A: saves {a, b} to disk
+        m_a = load_manifest(dir, :phase1)
+        add_complete!(m_a, ka)
+        add_complete!(m_a, kb)
+        save_manifest(m_a)
+
+        # Master B: has {b, c} in memory (b overlaps with A)
+        m_b = Manifest(:phase1, dir)
+        add_complete!(m_b, kb)
+        add_complete!(m_b, kc)
+        merge_and_save_manifest!(m_b)
+
+        # Reload: should contain {a, b, c}
+        m_final = load_manifest(dir, :phase1)
+        @test is_complete(m_final, ka)
+        @test is_complete(m_final, kb)
+        @test is_complete(m_final, kc)
+        @test length(m_final.complete) == 3
+    end
+end

--- a/test/run/test_run_keylock.jl
+++ b/test/run/test_run_keylock.jl
@@ -125,6 +125,8 @@ end
         # First run: permanent failure
         run!(k -> error("x"), v, keys; opts=RunOpts(max_attempts=2))
         @test !DataVault.is_done(v, keys[1])
+        # .running should be cleaned up by try-finally, not orphaned
+        @test !DataVault.is_running(v, keys[1])
 
         # Second run with working work_fn: should process the key
         counter = Ref(0)
@@ -136,5 +138,16 @@ end
         )
         @test counter[] == 1
         @test DataVault.is_done(v, keys[1])
+    end
+end
+
+@testset "run! + retry: .running never orphaned on error" begin
+    with_vault_l() do v, outdir
+        keys = allk(v)
+        # All keys fail permanently
+        run!(k -> error("boom"), v, keys; opts=RunOpts(max_attempts=2))
+        for k in keys
+            @test !DataVault.is_running(v, k)
+        end
     end
 end

--- a/test/run/test_run_keylock.jl
+++ b/test/run/test_run_keylock.jl
@@ -2,6 +2,11 @@ using ParallelManager, Test, DataVault, ParamIO, JSON3
 
 const FIXTURE_CFG_L = joinpath(@__DIR__, "fixtures", "study.toml")
 
+function _read_event_lines_l(outdir)
+    logs = filter(f -> startswith(f, "events_") && endswith(f, ".jsonl"), readdir(outdir))
+    vcat([readlines(joinpath(outdir, f)) for f in logs]...)
+end
+
 function with_vault_l(f; run::AbstractString="phase1")
     outdir = mktempdir()
     try
@@ -55,7 +60,7 @@ end
         ]
         foreach(wait, tasks)
 
-        lines = readlines(joinpath(outdir, "events.jsonl"))
+        lines = _read_event_lines_l(outdir)
         kinds = [JSON3.read(l).kind for l in lines]
         # Either some locks were busy, or one master finished everything so
         # fast the others saw :skip_complete. Both are acceptable outcomes.
@@ -84,7 +89,7 @@ end
         @test attempts[] == 3
         @test DataVault.is_done(v, keys[1])
 
-        lines = readlines(joinpath(outdir, "events.jsonl"))
+        lines = _read_event_lines_l(outdir)
         kinds = [JSON3.read(l).kind for l in lines]
         @test "retry" in kinds
         @test !("gave_up" in kinds)
@@ -108,7 +113,7 @@ end
         m = load_manifest(v)
         @test !is_complete(m, keys[1])
 
-        lines = readlines(joinpath(outdir, "events.jsonl"))
+        lines = _read_event_lines_l(outdir)
         kinds = [JSON3.read(l).kind for l in lines]
         @test "gave_up" in kinds
     end

--- a/test/run/test_run_loop.jl
+++ b/test/run/test_run_loop.jl
@@ -1,0 +1,83 @@
+using ParallelManager, Test, DataVault, ParamIO
+
+const FIXTURE_CFG_RL = joinpath(@__DIR__, "fixtures", "study.toml")
+
+function with_vault_rl(f; run::AbstractString="phase1")
+    outdir = mktempdir()
+    try
+        v = DataVault.Vault(FIXTURE_CFG_RL; run=run, outdir=outdir)
+        f(v, outdir)
+    finally
+        rm(outdir; recursive=true, force=true)
+    end
+end
+
+allk_rl(v) = ParamIO.expand(v.spec)
+
+@testset "run_loop!: all work done in first round, exits immediately" begin
+    with_vault_rl() do v, outdir
+        keys = allk_rl(v)
+        t0 = time()
+        run_loop!(
+            k -> Dict{String,Any}("x" => 1),
+            v,
+            keys;
+            max_empty_rounds=3,
+            idle_sleep=0.1,  # short for testing
+        )
+        elapsed = time() - t0
+        # Should finish quickly (not wait 3 idle rounds)
+        @test elapsed < 5.0
+        for k in keys
+            @test DataVault.is_done(v, k)
+        end
+    end
+end
+
+@testset "run_loop!: exits after max_empty_rounds of no new work" begin
+    with_vault_rl() do v, outdir
+        keys = allk_rl(v)
+        # Pre-complete all keys via manifest
+        m = load_manifest(v)
+        for k in keys
+            add_complete!(m, k)
+        end
+        save_manifest(m)
+        # Also mark done in DataVault
+        for k in keys
+            DataVault.mark_done!(v, k)
+        end
+
+        t0 = time()
+        run_loop!(
+            k -> Dict{String,Any}("x" => 1),
+            v,
+            keys;
+            max_empty_rounds=2,
+            idle_sleep=0.1,
+        )
+        elapsed = time() - t0
+        # Should exit after finding no work (early skip each round)
+        @test elapsed < 2.0
+    end
+end
+
+@testset "run_loop!: stop_flag causes immediate exit" begin
+    with_vault_rl() do v, outdir
+        keys = allk_rl(v)
+        stop = joinpath(outdir, "STOP")
+        touch(stop)
+
+        t0 = time()
+        run_loop!(
+            k -> Dict{String,Any}("x" => 1),
+            v,
+            keys;
+            opts=RunOpts(stop_flag=stop),
+            max_empty_rounds=3,
+            idle_sleep=0.1,
+        )
+        elapsed = time() - t0
+        @test elapsed < 2.0
+    end
+end

--- a/test/run/test_run_loop.jl
+++ b/test/run/test_run_loop.jl
@@ -50,11 +50,7 @@ end
 
         t0 = time()
         run_loop!(
-            k -> Dict{String,Any}("x" => 1),
-            v,
-            keys;
-            max_empty_rounds=2,
-            idle_sleep=0.1,
+            k -> Dict{String,Any}("x" => 1), v, keys; max_empty_rounds=2, idle_sleep=0.1
         )
         elapsed = time() - t0
         # Should exit after finding no work (early skip each round)

--- a/test/run/test_run_manifest.jl
+++ b/test/run/test_run_manifest.jl
@@ -2,6 +2,11 @@ using ParallelManager, Test, DataVault, ParamIO, JSON3
 
 const FIXTURE_CFG_M = joinpath(@__DIR__, "fixtures", "study.toml")
 
+function _read_event_lines_m(outdir)
+    logs = filter(f -> startswith(f, "events_") && endswith(f, ".jsonl"), readdir(outdir))
+    vcat([readlines(joinpath(outdir, f)) for f in logs]...)
+end
+
 function with_vault_m(f; run::AbstractString="phase1")
     outdir = mktempdir()
     try
@@ -50,7 +55,7 @@ end
         @test elapsed < 1.0  # early skip is fast
 
         # events.jsonl has :skip_complete
-        lines = readlines(joinpath(outdir, "events.jsonl"))
+        lines = _read_event_lines_m(outdir)
         kinds = [JSON3.read(l).kind for l in lines]
         @test "skip_complete" in kinds
     end

--- a/test/run/test_run_minimal.jl
+++ b/test/run/test_run_minimal.jl
@@ -2,6 +2,12 @@ using ParallelManager, Test, DataVault, ParamIO, JSON3
 
 const FIXTURE_CFG = joinpath(@__DIR__, "fixtures", "study.toml")
 
+# Helper: read all lines from per-master event log files in a directory
+function _read_event_lines(outdir)
+    logs = filter(f -> startswith(f, "events_") && endswith(f, ".jsonl"), readdir(outdir))
+    vcat([readlines(joinpath(outdir, f)) for f in logs]...)
+end
+
 function with_run_vault(f; run::AbstractString="phase1")
     outdir = mktempdir()
     try
@@ -39,9 +45,8 @@ end
         end
 
         # Events are recorded
-        events_path = joinpath(outdir, "events.jsonl")
-        @test isfile(events_path)
-        lines = readlines(events_path)
+        lines = _read_event_lines(outdir)
+        @test !isempty(lines)
         kinds = [JSON3.read(l).kind for l in lines]
         @test "stage_start" in kinds
         @test "stage_done" in kinds
@@ -68,7 +73,7 @@ end
             @test DataVault.is_done(v, k)
         end
 
-        lines = readlines(joinpath(outdir, "events.jsonl"))
+        lines = _read_event_lines(outdir)
         kinds = [JSON3.read(l).kind for l in lines]
         @test "error" in kinds
     end

--- a/test/run/test_run_stop_flag.jl
+++ b/test/run/test_run_stop_flag.jl
@@ -1,0 +1,70 @@
+using ParallelManager, Test, DataVault, ParamIO, JSON3
+
+const FIXTURE_CFG_S = joinpath(@__DIR__, "fixtures", "study.toml")
+
+function with_vault_s(f; run::AbstractString="phase1")
+    outdir = mktempdir()
+    try
+        v = DataVault.Vault(FIXTURE_CFG_S; run=run, outdir=outdir)
+        f(v, outdir)
+    finally
+        rm(outdir; recursive=true, force=true)
+    end
+end
+
+function _read_event_lines_s(outdir)
+    logs = filter(f -> startswith(f, "events_") && endswith(f, ".jsonl"), readdir(outdir))
+    vcat([readlines(joinpath(outdir, f)) for f in logs]...)
+end
+
+allk_s(v) = ParamIO.expand(v.spec)
+
+@testset "run! + stop_flag: pre-existing flag causes immediate return" begin
+    with_vault_s() do v, outdir
+        keys = allk_s(v)
+        stop = joinpath(outdir, "STOP_NOW")
+        touch(stop)
+
+        counter = Ref(0)
+        work_fn = k -> (counter[] += 1; Dict{String,Any}("x" => 1))
+        result = run!(work_fn, v, keys; opts=RunOpts(stop_flag=stop))
+
+        # No keys should be processed — stop was already set
+        @test counter[] == 0
+        @test result.done == 0
+    end
+end
+
+@testset "run! + stop_flag: flag raised mid-run causes partial results" begin
+    with_vault_s() do v, outdir
+        keys = allk_s(v)
+        @test length(keys) >= 2
+        stop = joinpath(outdir, "STOP_NOW")
+
+        call_count = Ref(0)
+        work_fn = k -> begin
+            call_count[] += 1
+            if call_count[] == 1
+                # After processing the first key, raise the stop flag
+                touch(stop)
+            end
+            sleep(0.01)
+            Dict{String,Any}("x" => 1)
+        end
+        result = run!(work_fn, v, keys; opts=RunOpts(stop_flag=stop))
+
+        # At least 1 key was done, but not all
+        @test result.done >= 1
+        @test result.done < length(keys)
+    end
+end
+
+@testset "run! + stop_flag: no flag means normal execution" begin
+    with_vault_s() do v, outdir
+        keys = allk_s(v)
+        result = run!(
+            k -> Dict{String,Any}("x" => 1), v, keys; opts=RunOpts(stop_flag=nothing)
+        )
+        @test result.done == length(keys)
+    end
+end


### PR DESCRIPTION
## Summary
#8 (try-finally + manifest merge) に続く並列安定化の残り。

- **stop_flag**: `RunOpts.stop_flag` で graceful shutdown。SIGUSR1 → STOP_NOW パターンを infra に統合
- **run_loop!**: FiniteTemperature.jl の work-stealing ループ (`MAX_EMPTY=3`, `WAIT_SECS=30`)
- **verify_workers!**: BLAS threads / CPU affinity の自動検証。segfault 原因の早期検出
- **per-master EventLog**: `events_{host}_{pid}.jsonl` で NFS 競合を解消 + `merge_event_logs` ユーティリティ
- **5 環境 CI**: TOML config + 共通 runner.jl で sequential / threaded(4) / distributed(2,4) / stress(10 masters) をマトリックス実行
- **テスト追加**: stop_flag, run_loop!, manifest merge, .running 孤立チェック (4228 tests pass)
- **version bump**: 0.1.1 → 0.2.0

## Test plan
- [x] 既存 + 新規テスト全 4228 pass (sequential 環境で検証済み)
- [x] CI runner.jl がローカルで正常動作
- [x] GitHub Actions で 5 環境マトリックスが pass