### PR TITLE
fix: verify_workers! probe must eval in worker's Main module

### DIFF
--- a/.github/ci/env_distributed_master_only.toml
+++ b/.github/ci/env_distributed_master_only.toml
@@ -1,0 +1,12 @@
+# Env 6: ISSP Slurm-like — workers are added via addprocs, but the user package
+# is loaded ONLY on the master. This mirrors the real production setup where
+# `init_workers!(mode=:slurm)` spawns worker Julia processes without first
+# doing `@everywhere using ParallelManager`. Exercises the verify_workers!
+# and pmap code paths that must not capture closures inside the package's
+# module scope.
+[env]
+mode = "distributed"
+n_workers = 2
+n_masters = 1
+test_dirs = ["init_workers", "run"]
+preload_workers = false

--- a/.github/ci/runner.jl
+++ b/.github/ci/runner.jl
@@ -25,11 +25,22 @@ ENV["PM_TEST_N_MASTERS"] = string(n_masters)
 
 # Launch Distributed workers when mode == "distributed"
 using Distributed  # always load; needed for nprocs() etc. in tests
+
+# `preload_workers` controls whether we do `@everywhere using ParallelManager`.
+# Production Slurm setups on ISSP load the package only on the master, which
+# previously masked a bug in verify_workers! (PkgId not found on workers).
+# Keep at least one env that tests the master-only scenario.
+preload_workers = get(env, "preload_workers", true)
+
 if mode == "distributed" && n_workers > 0
     project = dirname(Base.active_project())
     addprocs(n_workers; exeflags="--project=$project")
-    @everywhere using ParallelManager, DataVault, ParamIO
-    println("  Workers launched: $(workers())")
+    if preload_workers
+        @everywhere using ParallelManager, DataVault, ParamIO
+        println("  Workers launched (with PM preloaded): $(workers())")
+    else
+        println("  Workers launched (MASTER-ONLY: PM not loaded on workers): $(workers())")
+    end
 end
 
 # Load the package (must come after addprocs so @everywhere sees it)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,10 @@ jobs:
             env_file: .github/ci/env_distributed_4.toml
             julia_threads: 1
             version: '1'
+          - env_name: distributed-master-only
+            env_file: .github/ci/env_distributed_master_only.toml
+            julia_threads: 1
+            version: '1'
           - env_name: stress
             env_file: .github/ci/env_stress.toml
             julia_threads: 8

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParallelManager"
 uuid = "be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/InitWorkers.jl
+++ b/src/InitWorkers.jl
@@ -184,20 +184,28 @@ Ported from FiniteTemperature.jl `Parallel/Slurm.jl::print_worker_identities`.
 function verify_workers!()
     nprocs() > 1 || return nothing
     println("\n--- Worker verification ---")
+    # The probe closure MUST be evaluated in the worker's Main module —
+    # otherwise it gets serialized under ParallelManager's scope and
+    # deserialization fails on workers that haven't loaded ParallelManager
+    # (a common setup when compute.jl loads the package only on the master
+    # before calling init_workers!).
     futures = [
-        @spawnat p begin
-            cpuset = "N/A"
+        remotecall(Core.eval, p, Main, quote
+            local _cpuset = "N/A"
             try
                 for line in eachline("/proc/self/status")
                     if startswith(line, "Cpus_allowed_list:")
-                        cpuset = strip(split(line, ":")[2])
+                        _cpuset = strip(split(line, ":")[2])
                         break
                     end
                 end
             catch
             end
-            (myid(), gethostname(), Threads.nthreads(), BLAS.get_num_threads(), cpuset)
-        end for p in workers()
+            (Distributed.myid(), Base.gethostname(),
+             Threads.nthreads(),
+             LinearAlgebra.BLAS.get_num_threads(),
+             _cpuset)
+        end) for p in workers()
     ]
 
     for f in futures

--- a/src/InitWorkers.jl
+++ b/src/InitWorkers.jl
@@ -190,22 +190,30 @@ function verify_workers!()
     # (a common setup when compute.jl loads the package only on the master
     # before calling init_workers!).
     futures = [
-        remotecall(Core.eval, p, Main, quote
-            local _cpuset = "N/A"
-            try
-                for line in eachline("/proc/self/status")
-                    if startswith(line, "Cpus_allowed_list:")
-                        _cpuset = strip(split(line, ":")[2])
-                        break
+        remotecall(
+            Core.eval,
+            p,
+            Main,
+            quote
+                local _cpuset = "N/A"
+                try
+                    for line in eachline("/proc/self/status")
+                        if startswith(line, "Cpus_allowed_list:")
+                            _cpuset = strip(split(line, ":")[2])
+                            break
+                        end
                     end
+                catch
                 end
-            catch
-            end
-            (Distributed.myid(), Base.gethostname(),
-             Threads.nthreads(),
-             LinearAlgebra.BLAS.get_num_threads(),
-             _cpuset)
-        end) for p in workers()
+                (
+                    Distributed.myid(),
+                    Base.gethostname(),
+                    Threads.nthreads(),
+                    LinearAlgebra.BLAS.get_num_threads(),
+                    _cpuset,
+                )
+            end,
+        ) for p in workers()
     ]
 
     for f in futures

--- a/test/init_workers/test_verify_workers_adversarial.jl
+++ b/test/init_workers/test_verify_workers_adversarial.jl
@@ -1,0 +1,86 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Adversarial tests for verify_workers! and init_workers! probing.
+#
+# These tests reproduce the ISSP production scenario that the original
+# "happy path" tests missed: compute.jl loads ParallelManager on the
+# master, addprocs() spawns workers that do NOT have ParallelManager
+# loaded, then calls init_workers!(verbose=true) which invokes
+# verify_workers!.
+#
+# Before the fix, verify_workers!'s @spawnat closure was serialized inside
+# the ParallelManager module scope. Workers had no ParallelManager, so
+# deserialization threw:
+#
+#     KeyError: key Base.PkgId(..., "ParallelManager") not found
+#
+# The fix is to build the probe via `remotecall(Core.eval, p, Main, quote ... end)`
+# so the closure lives in the worker's Main module.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using ParallelManager, Test
+using Distributed, LinearAlgebra
+
+@testset "verify_workers! survives workers without ParallelManager" begin
+    # Start from a clean Distributed state
+    nprocs() > 1 && rmprocs(workers())
+    @test nprocs() == 1
+
+    # Spawn 2 workers with ONLY the current project — critically, we do
+    # NOT `@everywhere using ParallelManager`. This mirrors the ISSP
+    # Slurm case where init_workers! adds SlurmManager workers before
+    # compute.jl could possibly have loaded anything on them.
+    project = dirname(Base.active_project())
+    addprocs(2; exeflags="--project=$project")
+    @test nprocs() == 3
+
+    # Sanity: workers really don't have ParallelManager
+    worker_has_pm = remotecall_fetch(workers()[1]) do
+        Base.find_package("ParallelManager") !== nothing &&
+            haskey(Base.loaded_modules, Base.PkgId(
+                Base.UUID("be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"),
+                "ParallelManager",
+            ))
+    end
+    @test !worker_has_pm
+
+    # This is what used to crash: the verify_workers! probe must not
+    # close over ParallelManager symbols.
+    try
+        # Workers need LinearAlgebra so BLAS.get_num_threads resolves.
+        # In normal flow, init_workers!'s _apply_blas does this; we
+        # replicate it here so the test focuses on verify_workers!'s
+        # closure scope, not BLAS loading.
+        @everywhere workers() Core.eval(Main, :(using LinearAlgebra))
+
+        ParallelManager.verify_workers!()
+        @test true  # reached here → probe serialized/deserialized cleanly
+    catch e
+        @test false
+        @error "verify_workers! crashed on ParallelManager-less workers" exception=(e, catch_backtrace())
+    finally
+        rmprocs(workers())
+    end
+end
+
+@testset "verify_workers!: BLAS threads > 1 emits warning" begin
+    nprocs() > 1 && rmprocs(workers())
+    project = dirname(Base.active_project())
+    addprocs(1; exeflags="--project=$project")
+
+    try
+        @everywhere workers() Core.eval(Main, :(using LinearAlgebra))
+        # Deliberately set a high BLAS thread count on the worker
+        @everywhere workers() LinearAlgebra.BLAS.set_num_threads(4)
+
+        # Capture warnings via Test.@test_logs
+        @test_logs (:warn, r"BLAS threads=4") ParallelManager.verify_workers!()
+    finally
+        rmprocs(workers())
+    end
+end
+
+@testset "verify_workers!: no-op on single process" begin
+    # No workers → returns nothing without printing or erroring
+    @test nprocs() == 1
+    @test ParallelManager.verify_workers!() === nothing
+end

--- a/test/init_workers/test_verify_workers_adversarial.jl
+++ b/test/init_workers/test_verify_workers_adversarial.jl
@@ -35,11 +35,12 @@ using Distributed, LinearAlgebra
 
     # Sanity: workers really don't have ParallelManager
     worker_has_pm = remotecall_fetch(workers()[1]) do
-        Base.find_package("ParallelManager") !== nothing &&
-            haskey(Base.loaded_modules, Base.PkgId(
-                Base.UUID("be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"),
-                "ParallelManager",
-            ))
+        Base.find_package("ParallelManager") !== nothing && haskey(
+            Base.loaded_modules,
+            Base.PkgId(
+                Base.UUID("be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"), "ParallelManager"
+            ),
+        )
     end
     @test !worker_has_pm
 
@@ -56,7 +57,9 @@ using Distributed, LinearAlgebra
         @test true  # reached here → probe serialized/deserialized cleanly
     catch e
         @test false
-        @error "verify_workers! crashed on ParallelManager-less workers" exception=(e, catch_backtrace())
+        @error "verify_workers! crashed on ParallelManager-less workers" exception=(
+            e, catch_backtrace()
+        )
     finally
         rmprocs(workers())
     end

--- a/test/run/test_run_adversarial.jl
+++ b/test/run/test_run_adversarial.jl
@@ -159,9 +159,11 @@ end
 
         # 8 concurrent threads, very aggressive heartbeat
         tasks = [
-            Threads.@spawn(run!(work_fn, v, keys;
-                                opts=RunOpts(heartbeat_interval=0.05, stale_after=1.0)))
-            for _ in 1:8
+            Threads.@spawn(
+                run!(
+                    work_fn, v, keys; opts=RunOpts(heartbeat_interval=0.05, stale_after=1.0)
+                )
+            ) for _ in 1:8
         ]
         foreach(wait, tasks)
 
@@ -217,11 +219,7 @@ end
 @testset "run!: all keys fail → no crash, all .running cleaned" begin
     with_vault_a() do v, outdir
         keys = allk_a(v)
-        result = run!(
-            k -> error("always fails"),
-            v, keys;
-            opts=RunOpts(max_attempts=2)
-        )
+        result = run!(k -> error("always fails"), v, keys; opts=RunOpts(max_attempts=2))
         @test result.done == 0
         @test result.gave_up == length(keys)
         # No .running orphans

--- a/test/run/test_run_adversarial.jl
+++ b/test/run/test_run_adversarial.jl
@@ -1,0 +1,233 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Adversarial tests for run! / run_loop! / KeyLock / Manifest.
+#
+# These probe failure modes the happy-path tests miss:
+#  - stop_flag written DURING pmap fan-out (not only before run!)
+#  - KeyLock stale reclaim when holder dies (simulated by stale mtime)
+#  - Corrupt manifest.jld2 → empty manifest, no crash
+#  - work_fn that returns non-Dict / throws after partial completion
+#  - run! over a vault where some keys already have `.running` orphans
+#    (exactly the situation the try-finally fix in #8 created a regression for)
+# ─────────────────────────────────────────────────────────────────────────────
+
+using ParallelManager, Test, DataVault, ParamIO, JSON3, JLD2
+using Distributed
+
+const FIXTURE_CFG_A = joinpath(@__DIR__, "fixtures", "study.toml")
+
+function with_vault_a(f; run::AbstractString="phase1")
+    outdir = mktempdir()
+    try
+        v = DataVault.Vault(FIXTURE_CFG_A; run=run, outdir=outdir)
+        f(v, outdir)
+    finally
+        rm(outdir; recursive=true, force=true)
+    end
+end
+
+allk_a(v) = ParamIO.expand(v.spec)
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 1. stop_flag written mid-run by a concurrent task
+# ═════════════════════════════════════════════════════════════════════════════
+
+@testset "run!: stop_flag raised mid-execution by concurrent task" begin
+    with_vault_a() do v, outdir
+        keys = allk_a(v)
+        @test length(keys) >= 4
+
+        stop = joinpath(outdir, "STOP_NOW")
+        # Delay the stop flag by 50 ms so a few keys finish first
+        t = Timer(_ -> touch(stop), 0.05)
+
+        # work_fn sleeps so we're sure the stop is seen after some work
+        counter = Ref(0)
+        work_fn = k -> begin
+            counter[] += 1
+            sleep(0.02)
+            Dict{String,Any}("x" => 1)
+        end
+
+        result = run!(work_fn, v, keys; opts=RunOpts(stop_flag=stop))
+        close(t)
+
+        # At least one key ran before stop kicked in, at least one was skipped
+        @test result.done >= 1
+        @test result.done < length(keys)  # stop really cut us short
+        # Remaining keys are either counted as :stop (if we reached their
+        # dispatch) or just dropped from the todo list (sequential loop
+        # break). Either way, fewer done+stop than length means some were
+        # silently un-processed.
+        @test counter[] == result.done  # work_fn only called for done keys
+        isfile(stop) && rm(stop; force=true)
+    end
+end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 2. .running orphans from crashed prior runs are resumed cleanly
+# ═════════════════════════════════════════════════════════════════════════════
+
+@testset "run!: stale .running orphan is overwritten and completed" begin
+    with_vault_a() do v, outdir
+        keys = allk_a(v)
+        target = keys[1]
+
+        # Simulate a crashed prior run: .running exists but no .done
+        DataVault.mark_running!(v, target)
+        @test DataVault.is_running(v, target)
+        @test !DataVault.is_done(v, target)
+
+        # New run should still process this key (try-finally guards ensure
+        # clear_running! is always called)
+        work_fn = k -> Dict{String,Any}("x" => 1)
+        result = run!(work_fn, v, keys)
+        @test result.done == length(keys)
+        @test DataVault.is_done(v, target)
+        # .running must be cleaned up
+        @test !DataVault.is_running(v, target)
+    end
+end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 3. Corrupt manifest.jld2 → treated as empty, run completes normally
+# ═════════════════════════════════════════════════════════════════════════════
+
+@testset "run!: corrupt manifest.jld2 is recoverable" begin
+    with_vault_a() do v, outdir
+        keys = allk_a(v)
+        # Write a garbage file where the manifest would be
+        mpath = manifest_path(manifest_root(v), Symbol(v.run))
+        mkpath(dirname(mpath))
+        write(mpath, "this is not a JLD2 file")
+        @test isfile(mpath)
+
+        # run! should not crash; load_manifest returns empty and runs all keys
+        work_fn = k -> Dict{String,Any}("x" => 1)
+        result = run!(work_fn, v, keys)
+        @test result.done == length(keys)
+        # After run, the corrupt file is overwritten with a valid manifest
+        m = load_manifest(v)
+        @test length(m.complete) == length(keys)
+    end
+end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 4. KeyLock: stale reclaim when holder died before first heartbeat
+# ═════════════════════════════════════════════════════════════════════════════
+
+@testset "KeyLock: reclaim of a stale lock without heartbeat file" begin
+    mktempdir() do dir
+        # Simulate a dead holder: acquired the lock (mkdir) but died before
+        # the first heartbeat touch → no heartbeat file inside.
+        lock_dir = joinpath(dir, "k")
+        l = KeyLock(lock_dir; stale_after=0.01, heartbeat_interval=0.005)
+
+        # Manually create lock dir without heartbeat (dead holder state)
+        mkdir(lock_dir)
+        write(joinpath(lock_dir, "holder"), "ghost:9999")
+        # No heartbeat file → is_stale should fall back to dir mtime
+
+        sleep(0.05)  # Wait beyond stale_after
+        @test is_stale(l) == true
+
+        # Another contender should be able to reclaim + acquire
+        @test try_acquire(l) == true
+        @test isdir(lock_dir)
+        # heartbeat file should now exist (fresh acquisition)
+        @test isfile(joinpath(lock_dir, "heartbeat"))
+        release!(l)
+    end
+end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 5. Multi-task race with VERY short heartbeat interval
+#    (stress test: ensures heartbeat loop doesn't deadlock with release)
+# ═════════════════════════════════════════════════════════════════════════════
+
+@testset "run!: 8-master race with fast heartbeat (stress)" begin
+    with_vault_a() do v, outdir
+        keys = allk_a(v)
+        invoked = Dict{String,Threads.Atomic{Int}}()
+        for k in keys
+            invoked[canonical(k)] = Threads.Atomic{Int}(0)
+        end
+        work_fn = k -> begin
+            Threads.atomic_add!(invoked[canonical(k)], 1)
+            sleep(0.01)
+            Dict{String,Any}("x" => 1)
+        end
+
+        # 8 concurrent threads, very aggressive heartbeat
+        tasks = [
+            Threads.@spawn(run!(work_fn, v, keys;
+                                opts=RunOpts(heartbeat_interval=0.05, stale_after=1.0)))
+            for _ in 1:8
+        ]
+        foreach(wait, tasks)
+
+        for k in keys
+            @test DataVault.is_done(v, k)
+            # Under contention, each key should be invoked at most a few times
+            # (ideally exactly once, but re-runs inside stale reclaim windows
+            # are acceptable)
+            @test invoked[canonical(k)][] >= 1
+            @test invoked[canonical(k)][] <= 3
+        end
+    end
+end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 6. merge_and_save_manifest!: two concurrent masters don't lose keys
+# ═════════════════════════════════════════════════════════════════════════════
+
+@testset "merge_and_save_manifest!: preserves keys across concurrent writers" begin
+    with_vault_a() do v, outdir
+        # Pre-create two disjoint manifests on different in-memory objects
+        # but same on-disk location, simulate race where each master
+        # starts with its own completed set.
+        ka = ParamIO.DataKey(Dict{String,Any}("N" => 4, "J" => 0.5), 0)
+        kb = ParamIO.DataKey(Dict{String,Any}("N" => 4, "J" => 1.0), 0)
+        kc = ParamIO.DataKey(Dict{String,Any}("N" => 8, "J" => 0.5), 0)
+
+        root = manifest_root(v)
+        stage = Symbol(v.run)
+
+        m_A = Manifest(stage, root)
+        add_complete!(m_A, ka)
+        add_complete!(m_A, kb)
+        # Save A's state first (plain save, like an older master might have done)
+        save_manifest(m_A)
+
+        # Master B has only {c} in memory; merges should give {a,b,c}
+        m_B = Manifest(stage, root)
+        add_complete!(m_B, kc)
+        merge_and_save_manifest!(m_B)
+
+        final = load_manifest(root, stage)
+        @test is_complete(final, ka)
+        @test is_complete(final, kb)
+        @test is_complete(final, kc)
+    end
+end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 7. run! doesn't crash when work_fn throws on EVERY key
+# ═════════════════════════════════════════════════════════════════════════════
+
+@testset "run!: all keys fail → no crash, all .running cleaned" begin
+    with_vault_a() do v, outdir
+        keys = allk_a(v)
+        result = run!(
+            k -> error("always fails"),
+            v, keys;
+            opts=RunOpts(max_attempts=2)
+        )
+        @test result.done == 0
+        @test result.gave_up == length(keys)
+        # No .running orphans
+        for k in keys
+            @test !DataVault.is_running(v, k)
+            @test !DataVault.is_done(v, k)
+        end
+    end
+end


### PR DESCRIPTION
## Bug
ISSP 実行時に以下のエラーで compute.jl がクラッシュ:
\`\`\`
KeyError: key Base.PkgId(..., \"ParallelManager\") not found
[7] init_workers!(; ...) @ ParallelManager .../InitWorkers.jl:123
\`\`\`

**原因**: \`@spawnat p begin ... end\` で作る closure が ParallelManager module scope に captured され、worker 側で deserialize するとき ParallelManager module が必要。compute.jl が master でのみ \`using ParallelManager\` する場合 (= Slurm の典型的な setup) に fail する。

## Fix
\`remotecall(Core.eval, p, Main, quote ... end)\` で probe を worker の Main module で評価するように変更。\`LinearAlgebra.BLAS\`, \`Distributed.myid\`, \`Base.gethostname\` を fully qualified で参照し symbol resolution も安全に。

## Test plan
- [x] CI threaded 環境 (4 threads, 4 masters) で 4228 テスト pass
- [ ] ISSP i8cpu 実機で init_workers!(:slurm) → verify_workers! が動作確認

Bump: 0.2.0 → 0.2.1