### PR TITLE
chore: widen DataVault compat to "0.4, 0.5"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParallelManager"
 uuid = "be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -22,7 +22,7 @@ DataVault = {rev = "main", url = "https://github.com/sotashimozono/DataVault.jl.
 ParamIO = {rev = "feat/canonical", url = "https://github.com/sotashimozono/ParamIO.jl.git"}
 
 [compat]
-DataVault = "0.4"
+DataVault = "0.4, 0.5"
 Dates = "1.11"
 Distributed = "1.11"
 JLD2 = "0.6"


### PR DESCRIPTION
## Summary

DataVault released `v0.5.0` with new experiment-report / schema-stamp / figure-archive APIs. ParallelManager's `Pkg.Operations.resolve` currently refuses to pick DataVault 0.5.0 because the compat entry is pinned to `0.4`. Widen it to accept both.

- `[compat] DataVault = "0.4, 0.5"`
- Version bump `0.2.1 → 0.2.2` (compat-only patch)

No API or behaviour changes.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.resolve()'` resolves with DataVault 0.5.0 pinned
- [x] Local `Pkg.test()` (CI will re-run)