### PR TITLE
chore: widen DataVault compat to "0.4, 0.5, 0.6"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParallelManager"
 uuid = "be946ad2-3cb3-4b6e-8f7e-4a5ecc3c255b"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -22,7 +22,7 @@ DataVault = {rev = "main", url = "https://github.com/sotashimozono/DataVault.jl.
 ParamIO = {rev = "feat/canonical", url = "https://github.com/sotashimozono/ParamIO.jl.git"}
 
 [compat]
-DataVault = "0.4, 0.5"
+DataVault = "0.4, 0.5, 0.6"
 Dates = "1.11"
 Distributed = "1.11"
 JLD2 = "0.6"


### PR DESCRIPTION
## Summary

DataVault v0.6.0 is out with the experiment-workflow module and is blocked by ParallelManager's compat pin.  Widen the range the same way as #11.

- \`[compat] DataVault = "0.4, 0.5, 0.6"\`
- Version bump \`0.2.2 → 0.2.3\` (compat-only patch)

No API or behaviour changes.

## Test plan

- [x] \`julia --project=. -e 'using Pkg; Pkg.resolve()'\` succeeds with DataVault 0.6.0 pinned downstream.
- [x] \`Pkg.test()\` (CI will re-run).