### PR TITLE
feat(eventlog): log levels — suppress per-key lock_busy/key_start by default

### DIFF
--- a/src/EventLog.jl
+++ b/src/EventLog.jl
@@ -45,8 +45,11 @@ one `write(io, line)` call to stay within that guarantee.
 | `gave_up`       | all `max_attempts` attempts exhausted                             |
 | `skip_complete` | full-done early exit (manifest had every key)                     |
 
-Downstream analysis (`jq`, DataFrame-based) can filter and aggregate over
-these kinds without ever parsing freeform text.
+`:key_start` and `:lock_busy` are emitted at `:debug` level and are suppressed
+unless the `EventLog` is created with `min_level=:debug` (see `RunOpts.log_level`);
+their totals still appear in `:stage_done`. Downstream analysis (`jq`,
+DataFrame-based) can filter and aggregate over these kinds without ever parsing
+freeform text.
 
 # Example
 
@@ -60,9 +63,28 @@ log_event(log, :stage_done; stage=:phase1, done=3600, err=0)
 struct EventLog
     path::String
     lock::ReentrantLock
+    min_level::Int
 end
 
-EventLog(path::AbstractString) = EventLog(String(path), ReentrantLock())
+function EventLog(path::AbstractString; min_level::Symbol=:info)
+    return EventLog(String(path), ReentrantLock(), _level_value(min_level))
+end
+
+# Severity ladder (à la Julia logging). Events below an `EventLog`'s `min_level`
+# are dropped — used to keep high-churn `:debug` events (per-key `:lock_busy`,
+# `:key_start`) out of the log by default while preserving the aggregate counts
+# carried in `:stage_done`.
+function _level_value(l::Symbol)::Int
+    l === :debug && return 10
+    l === :info && return 20
+    l === :warn && return 30
+    l === :error && return 40
+    throw(
+        ArgumentError(
+            "EventLog: unknown level $(repr(l)) (use :debug/:info/:warn/:error)"
+        ),
+    )
+end
 
 """
     log_event(log, kind; kwargs...)
@@ -88,7 +110,10 @@ produces one line like:
 
 Returns `nothing`.
 """
-function log_event(log::EventLog, kind::Symbol; kwargs...)
+function log_event(log::EventLog, kind::Symbol; level::Symbol=:info, kwargs...)
+    # Drop events below the log's threshold. `level` is consumed here (a filter
+    # decision); it is NOT written into the JSON — the `kind` already implies it.
+    _level_value(level) < log.min_level && return nothing
     rec = (; ts=string(now()), kind=String(kind), kwargs...)
     # Build the full line with newline so a single `write` is one atomic
     # append on POSIX (given `O_APPEND` and size < PIPE_BUF).

--- a/src/EventLog.jl
+++ b/src/EventLog.jl
@@ -80,9 +80,7 @@ function _level_value(l::Symbol)::Int
     l === :warn && return 30
     l === :error && return 40
     throw(
-        ArgumentError(
-            "EventLog: unknown level $(repr(l)) (use :debug/:info/:warn/:error)"
-        ),
+        ArgumentError("EventLog: unknown level $(repr(l)) (use :debug/:info/:warn/:error)")
     )
 end
 

--- a/src/Run.jl
+++ b/src/Run.jl
@@ -34,6 +34,11 @@ Execution options for [`run!`](@ref).
 - `heartbeat_interval::Float64 = 60.0` — how often the per-lock heartbeat task
   refreshes DataVault's `.running` file. Enforced to be `<` `stale_after`
   (otherwise a live holder's lock could be reclaimed mid-work).
+- `log_level::Symbol = :info` — event-log verbosity. At `:info` (default) the
+  high-churn per-key `:lock_busy` and `:key_start` events are suppressed (their
+  totals still ride in the `:stage_done` summary), keeping the JSONL log
+  O(computed keys) instead of O(masters × keys) under multi-master contention.
+  Set `:debug` to log them (e.g. to debug lock contention).
 - `stop_flag::Union{String,Nothing} = nothing` — path to a sentinel file.
   When `isfile(stop_flag)` becomes true, [`run!`](@ref) and
   [`run_loop!`](@ref) stop dispatching new keys and return early. This is
@@ -55,6 +60,7 @@ struct RunOpts
     stale_after::Float64
     heartbeat_interval::Float64
     stop_flag::Union{String,Nothing}
+    log_level::Symbol
 end
 
 function RunOpts(;
@@ -63,10 +69,16 @@ function RunOpts(;
     stale_after::Real=600.0,
     heartbeat_interval::Real=60.0,
     stop_flag::Union{String,Nothing}=nothing,
+    log_level::Symbol=:info,
 )
     workers in (:auto, :sequential) || throw(
         ArgumentError(
             "RunOpts: workers must be :auto or :sequential, got $(repr(workers))"
+        ),
+    )
+    log_level in (:debug, :info, :warn, :error) || throw(
+        ArgumentError(
+            "RunOpts: log_level must be :debug/:info/:warn/:error, got $(repr(log_level))"
         ),
     )
     heartbeat_interval < stale_after || throw(
@@ -77,7 +89,12 @@ function RunOpts(;
         ),
     )
     return RunOpts(
-        workers, max_attempts, Float64(stale_after), Float64(heartbeat_interval), stop_flag
+        workers,
+        max_attempts,
+        Float64(stale_after),
+        Float64(heartbeat_interval),
+        stop_flag,
+        log_level,
     )
 end
 
@@ -161,7 +178,7 @@ function run!(
 )
     stage = Symbol(vault.run)
     log_name = "events_$(gethostname())_$(getpid()).jsonl"
-    log = EventLog(joinpath(vault.outdir, log_name))
+    log = EventLog(joinpath(vault.outdir, log_name); min_level=opts.log_level)
 
     # Early skip: load manifest, subtract completed keys
     m = load_manifest(vault)
@@ -272,7 +289,7 @@ function _run_one_with_lock!(
     # `:ok` / `:reclaimed`; the losers see `:busy`.
     acq = DataVault.acquire_running!(vault, key; stale_after=opts.stale_after)
     if acq === :busy
-        log_event(log, :lock_busy; stage=stage, key=kstr)
+        log_event(log, :lock_busy; level=:debug, stage=stage, key=kstr)
         return (key, :lock_busy)
     end
     # acq ∈ (:ok, :reclaimed) — we own the lock.
@@ -444,7 +461,7 @@ function _run_one_with_retry!(
 )
     last_err = nothing
     for attempt in 1:opts.max_attempts
-        log_event(log, :key_start; stage=stage, key=kstr, attempt=attempt)
+        log_event(log, :key_start; level=:debug, stage=stage, key=kstr, attempt=attempt)
         t0 = time()
         try
             payload = work_fn(key)

--- a/src/Run.jl
+++ b/src/Run.jl
@@ -78,7 +78,7 @@ function RunOpts(;
     )
     log_level in (:debug, :info, :warn, :error) || throw(
         ArgumentError(
-            "RunOpts: log_level must be :debug/:info/:warn/:error, got $(repr(log_level))"
+            "RunOpts: log_level must be :debug/:info/:warn/:error, got $(repr(log_level))",
         ),
     )
     heartbeat_interval < stale_after || throw(

--- a/test/run/test_event_log_level.jl
+++ b/test/run/test_event_log_level.jl
@@ -1,0 +1,49 @@
+using ParallelManager, Test, DataVault, ParamIO, JSON3
+
+isdefined(@__MODULE__, :FIXTURE_CFG) ||
+    (const FIXTURE_CFG = joinpath(@__DIR__, "fixtures", "study.toml"))
+
+_kinds(path) = [JSON3.read(l).kind for l in readlines(path) if !isempty(l)]
+
+@testset "EventLog: min_level filters by event level" begin
+    mktempdir() do dir
+        p = joinpath(dir, "e.jsonl")
+        log = ParallelManager.EventLog(p)                 # default :info
+        ParallelManager.log_event(log, :noisy; level=:debug)
+        ParallelManager.log_event(log, :important)        # level defaults to :info
+        k = _kinds(p)
+        @test !("noisy" in k)                             # :debug dropped
+        @test "important" in k
+
+        p2 = joinpath(dir, "e2.jsonl")
+        log2 = ParallelManager.EventLog(p2; min_level=:debug)
+        ParallelManager.log_event(log2, :noisy; level=:debug)
+        ParallelManager.log_event(log2, :important)
+        k2 = _kinds(p2)
+        @test "noisy" in k2                               # :debug now kept
+        @test "important" in k2
+    end
+end
+
+@testset "EventLog/RunOpts: unknown level rejected" begin
+    @test_throws ArgumentError ParallelManager.EventLog(tempname(); min_level=:bogus)
+    @test_throws ArgumentError RunOpts(; log_level=:bogus)
+end
+
+@testset "run!: default suppresses key_start; :debug logs it" begin
+    for (lvl, expect_start) in ((:info, false), (:debug, true))
+        outdir = mktempdir()
+        try
+            v = DataVault.Vault(FIXTURE_CFG; run="phase1", outdir=outdir)
+            keys = ParamIO.expand(v.spec)
+            run!(k -> Dict{String,Any}("x" => 1), v, keys; opts=RunOpts(; log_level=lvl))
+            logf = only(filter(f -> startswith(f, "events_"), readdir(outdir)))
+            k = _kinds(joinpath(outdir, logf))
+            @test "key_done" in k                          # :info — always logged
+            @test "stage_done" in k                        # :info — always logged
+            @test ("key_start" in k) == expect_start       # :debug — only when :debug
+        finally
+            rm(outdir; recursive=true, force=true)
+        end
+    end
+end

--- a/test/run/test_run_keylock.jl
+++ b/test/run/test_run_keylock.jl
@@ -57,7 +57,12 @@ end
         # :lock_busy is a :debug event — opt into it via log_level=:debug to assert it.
         tasks = [
             Threads.@spawn(
-                run!(work_fn, v, keys; opts=RunOpts(; heartbeat_interval=10.0, log_level=:debug))
+                run!(
+                    work_fn,
+                    v,
+                    keys;
+                    opts=RunOpts(; heartbeat_interval=10.0, log_level=:debug),
+                )
             ) for _ in 1:4
         ]
         foreach(wait, tasks)

--- a/test/run/test_run_keylock.jl
+++ b/test/run/test_run_keylock.jl
@@ -54,9 +54,11 @@ end
     with_vault_l() do v, outdir
         keys = allk(v)
         work_fn = k -> (sleep(0.02); Dict{String,Any}("x" => 1))
+        # :lock_busy is a :debug event — opt into it via log_level=:debug to assert it.
         tasks = [
-            Threads.@spawn(run!(work_fn, v, keys; opts=RunOpts(heartbeat_interval=10.0)))
-            for _ in 1:4
+            Threads.@spawn(
+                run!(work_fn, v, keys; opts=RunOpts(; heartbeat_interval=10.0, log_level=:debug))
+            ) for _ in 1:4
         ]
         foreach(wait, tasks)
 

--- a/test/run/test_run_minimal.jl
+++ b/test/run/test_run_minimal.jl
@@ -50,7 +50,8 @@ end
         kinds = [JSON3.read(l).kind for l in lines]
         @test "stage_start" in kinds
         @test "stage_done" in kinds
-        @test count(==("key_start"), kinds) == length(keys)
+        # key_start is :debug — suppressed by default; key_done (:info) is the per-key signal
+        @test count(==("key_start"), kinds) == 0
         @test count(==("key_done"), kinds) == length(keys)
     end
 end


### PR DESCRIPTION
## What

Adds a log level to `EventLog` so the high-churn per-key events are suppressed by
default — fixing event-log bloat on resumed / multi-master sweeps. Only *what is
logged* changes; *what is computed* is unchanged.

## The problem

On a multi-master sweep, every master attempts every `todo` key and the losers
each log a `:lock_busy` event → **O(masters × keys)** "I-didn't-do-this-one"
lines. `:key_start` also fires per key per attempt. These dominated the JSONL
log with entries irrelevant to the actual work — while their totals were
*already* available in the `:stage_done` summary.

## The change

- `EventLog(path; min_level=:info)` + `log_event(log, kind; level=:info, …)` —
  events below `min_level` are dropped. `level` is a filter decision, **not**
  written into the JSON.
- `:lock_busy` and `:key_start` now emit at `:debug`; everything meaningful
  (`key_done`, `error`, `gave_up`, `lock_lost`, `stage_*`, `skip_complete`,
  `retry`) stays `:info`.
- `RunOpts(; log_level=:info)` (default) → `run!` builds the `EventLog` at that
  level. Set `:debug` to log contention detail.

Result: the JSONL log is **O(computed keys)** by default; the suppressed totals
still ride in `:stage_done` (`busy`/`done`/`skipped`/…), so no information is
lost. Backward-compatible — existing `log_event` calls without `level=` default
to `:info` and are still written (so `test/eventlog` is unaffected).

### Demo (4 keys × 4 contending masters)

```
event-log lines  :info (default) = 11
event-log lines  :debug          = 20
```

The 9-line gap is the suppressed `key_start`/`lock_busy`; it scales as
O(masters × keys), so a thousands-of-keys × tens-of-masters sweep goes from a
multi-GB log to a lean one.

## Tests

`test/run/test_event_log_level.jl` — level filtering at the `EventLog` level and
through `run!` (default suppresses `key_start`; `:debug` logs it); unknown level
rejected. Updated `test_run_minimal` (`key_start` now debug-suppressed) and
`test_run_keylock` (opts into `:debug` to assert `:lock_busy`). Suite green
(**4300 tests**, `--threads=2`).
